### PR TITLE
Add upstream dialer support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,4 @@ fabric.properties
 # Editor-based Rest Client
 .idea/httpRequests
 
+.vscode

--- a/dial_test.go
+++ b/dial_test.go
@@ -1,9 +1,11 @@
 package raknet_test
 
 import (
-	"github.com/sandertv/go-raknet"
+	"net"
 	"strings"
 	"testing"
+
+	"github.com/sandertv/go-raknet"
 )
 
 func TestPing(t *testing.T) {
@@ -23,6 +25,34 @@ func TestPing(t *testing.T) {
 	}
 }
 
+func TestPingWithCustomDialer(t *testing.T) {
+	//noinspection SpellCheckingInspection
+	const (
+		addr   = "mco.mineplex.com:19132"
+		prefix = "MCPE"
+	)
+
+	localDialAddr, err := net.ResolveUDPAddr("udp", "0.0.0.0:55556")
+	if err != nil {
+		t.Fatalf("error resolving local dial address: %v", err)
+	}
+
+	dialer := raknet.Dialer{
+		UpstreamDialer: net.Dialer{
+			LocalAddr: localDialAddr,
+		},
+	}
+
+	data, err := dialer.Ping(addr)
+	if err != nil {
+		t.Fatalf("error pinging %v: %v", addr, err)
+	}
+	str := string(data)
+	if !strings.HasPrefix(str, prefix) {
+		t.Fatalf("ping data should have prefix %v, but got %v", prefix, str)
+	}
+}
+
 func TestDial(t *testing.T) {
 	//noinspection SpellCheckingInspection
 	const (
@@ -30,6 +60,31 @@ func TestDial(t *testing.T) {
 	)
 
 	conn, err := raknet.Dial(addr)
+	if err != nil {
+		t.Fatalf("error connecting to %v: %v", addr, err)
+	}
+	if err := conn.Close(); err != nil {
+		t.Fatalf("error closing connection: %v", err)
+	}
+}
+
+func TestDialWithCustomDialer(t *testing.T) {
+	//noinspection SpellCheckingInspection
+	const (
+		addr = "mco.mineplex.com:19132"
+	)
+
+	localDialAddr, err := net.ResolveUDPAddr("udp", "0.0.0.0:55555")
+	if err != nil {
+		t.Fatalf("error resolving local dial address: %v", err)
+	}
+
+	dialer := raknet.Dialer{
+		UpstreamDialer: net.Dialer{
+			LocalAddr: localDialAddr,
+		},
+	}
+	conn, err := dialer.Dial(addr)
 	if err != nil {
 		t.Fatalf("error connecting to %v: %v", addr, err)
 	}


### PR DESCRIPTION
This pull request will allow an upstream net.Dialer to be supplied for outgoing raknet connections. A use-case where this ability was needed was to specify the local IP address that pings/connections would go out from.