### PR TITLE
Bumped protocol version for v1.19.30

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	// currentProtocol is the current RakNet protocol version. This is Minecraft specific.
-	currentProtocol byte = 10
+	currentProtocol = 11
 
 	maxMTUSize    = 1400
 	maxWindowSize = 2048

--- a/conn.go
+++ b/conn.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	// currentProtocol is the current RakNet protocol version. This is Minecraft specific.
-	currentProtocol = 11
+	currentProtocol byte = 11
 
 	maxMTUSize    = 1400
 	maxWindowSize = 2048


### PR DESCRIPTION
The RakNet protocol version was bumped in v1.19.30 because of the login sequence changes. Nothing else RakNet related was affected.