### PR TITLE
Fix Crashing When byte is too big

### DIFF
--- a/listener.go
+++ b/listener.go
@@ -180,8 +180,12 @@ func (listener *Listener) listen() {
 	for {
 		n, addr, err := listener.conn.ReadFrom(b)
 		if err != nil {
-			close(listener.incoming)
-			return
+			if errors.Is(err, net.ErrClosed) {
+				close(listener.incoming)
+				return
+			}
+			listener.conf.ErrorLog.Error("read from: "+err.Error())
+			continue
 		} else if n == 0 || listener.sec.blocked(addr) {
 			continue
 		}


### PR DESCRIPTION
This fixes a huge problem with unexpected crashes happening to the underlying raknet listener when it shouldn't crash.