### PR TITLE
Add multi ordering-channel support

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -56,8 +56,9 @@ type Conn struct {
 
 	pk *packet
 
-	seq, orderIndex, messageIndex uint24
-	splitID                       uint32
+	seq, messageIndex uint24
+	orderIndex        [256]uint24
+	splitID           uint32
 
 	// mtu is the MTU size of the connection. Packets longer than this size
 	// must be split into fragments for them to arrive at the client without
@@ -80,9 +81,9 @@ type Conn struct {
 	// in an ACK and the slice is cleared.
 	ackSlice []uint24
 
-	// packetQueue is an ordered queue containing packets indexed by their order
-	// index.
-	packetQueue *packetQueue
+	// packetQueue is a set of ordered queues containing packets indexed by
+	// order channel and order index.
+	packetQueue *packetChannelQueue
 	// packets is a channel containing content of packets that were fully
 	// processed. Calling Conn.Read() consumes a value from this channel.
 	packets *internal.ElasticChan[[]byte]
@@ -108,7 +109,7 @@ func newConn(conn net.PacketConn, raddr net.Addr, mtu uint16, h connectionHandle
 		packets:        internal.Chan[[]byte](4, 4096),
 		splits:         make(map[uint16][][]byte),
 		win:            newDatagramWindow(),
-		packetQueue:    newPacketQueue(),
+		packetQueue:    newPacketChannelQueue(),
 		retransmission: newRecoveryQueue(),
 		buf:            bytes.NewBuffer(make([]byte, 0, mtu-28)), // - headers.
 		ackBuf:         bytes.NewBuffer(make([]byte, 0, 128)),
@@ -225,6 +226,12 @@ func (conn *Conn) Write(b []byte) (n int, err error) {
 	return conn.writeWithReliability(b, reliabilityReliableOrdered)
 }
 
+// WriteChannel writes a reliable ordered packet to a specific RakNet ordering
+// channel.
+func (conn *Conn) WriteChannel(b []byte, orderChannel byte) (n int, err error) {
+	return conn.writeWithReliabilityAndChannel(b, reliabilityReliableOrdered, orderChannel)
+}
+
 // writeWithReliability writes a buffer b over the RakNet connection using the
 // reliability passed. The amount of bytes written n is always equal to the
 // length of the bytes written if writing was successful. If not, an error is
@@ -232,13 +239,17 @@ func (conn *Conn) Write(b []byte) (n int, err error) {
 // multiple goroutines, but will write one by one. Unlike Write, it allows
 // specifying the reliability.
 func (conn *Conn) writeWithReliability(b []byte, rel reliability) (n int, err error) {
+	return conn.writeWithReliabilityAndChannel(b, rel, 0)
+}
+
+func (conn *Conn) writeWithReliabilityAndChannel(b []byte, rel reliability, orderChannel byte) (n int, err error) {
 	select {
 	case <-conn.ctx.Done():
 		return 0, conn.error(net.ErrClosed, "write")
 	default:
 		conn.mu.Lock()
 		defer conn.mu.Unlock()
-		n, err = conn.write(b, rel)
+		n, err = conn.write(b, rel, orderChannel)
 		return n, conn.error(err, "write")
 	}
 }
@@ -248,11 +259,11 @@ func (conn *Conn) writeWithReliability(b []byte, rel reliability) (n int, err er
 // was successful. If not, an error is returned and n is 0. Write may be called
 // simultaneously from multiple goroutines, but will write one by one. Unlike
 // Write, write will not lock.
-func (conn *Conn) write(b []byte, rel reliability) (n int, err error) {
+func (conn *Conn) write(b []byte, rel reliability, orderChannel byte) (n int, err error) {
 	fragments := split(b, conn.effectiveMTU())
 	var orderIndex uint24
 	if rel.sequencedOrOrdered() {
-		orderIndex = conn.orderIndex.Inc()
+		orderIndex = conn.orderIndex[orderChannel].Inc()
 	}
 
 	splitID := uint16(conn.splitID)
@@ -271,6 +282,11 @@ func (conn *Conn) write(b []byte, rel reliability) (n int, err error) {
 		copy(pk.content, content)
 
 		pk.orderIndex = orderIndex
+		if rel.sequencedOrOrdered() {
+			pk.orderChannel = orderChannel
+		} else {
+			pk.orderChannel = 0
+		}
 		pk.reliability = rel
 		if rel.reliable() {
 			pk.messageIndex = conn.messageIndex.Inc()
@@ -477,14 +493,19 @@ func (conn *Conn) receivePacket(packet *packet) error {
 		// If it isn't a reliable ordered packet, handle it immediately.
 		return conn.handlePacket(packet.content)
 	}
-	if !conn.packetQueue.put(packet.orderIndex, packet.content) {
+	if !conn.packetQueue.put(packet.orderChannel, packet.orderIndex, packet.content) {
 		// An ordered packet arrived twice.
 		return nil
 	}
-	if conn.packetQueue.WindowSize() > maxWindowSize && conn.handler.limitsEnabled() {
-		return fmt.Errorf("packet queue window size is too big (%v-%v)", conn.packetQueue.lowest, conn.packetQueue.highest)
+	totalWindowSize := conn.packetQueue.TotalWindowSize()
+	if totalWindowSize > maxWindowSize && conn.handler.limitsEnabled() {
+		lowest, highest := conn.packetQueue.WindowBounds(packet.orderChannel)
+		return fmt.Errorf(
+			"packet queue window size is too big (%v total, channel %v: %v-%v)",
+			totalWindowSize, packet.orderChannel, lowest, highest,
+		)
 	}
-	for _, content := range conn.packetQueue.fetch() {
+	for _, content := range conn.packetQueue.fetch(packet.orderChannel) {
 		if err := conn.handlePacket(content); err != nil {
 			return err
 		}

--- a/ordering_channels_test.go
+++ b/ordering_channels_test.go
@@ -1,0 +1,151 @@
+package raknet
+
+import (
+	"bytes"
+	"io"
+	"net"
+	"testing"
+	"time"
+)
+
+func TestPacketReadWriteOrderChannel(t *testing.T) {
+	in := &packet{
+		reliability:  reliabilityReliableOrdered,
+		messageIndex: 33,
+		orderIndex:   19,
+		orderChannel: 7,
+		content:      []byte{0x10, 0x20, 0x30},
+	}
+	var buf bytes.Buffer
+	in.write(&buf)
+
+	var out packet
+	n, err := out.read(buf.Bytes())
+	if err != nil {
+		t.Fatalf("read packet: %v", err)
+	}
+	if n != buf.Len() {
+		t.Fatalf("read bytes mismatch: got %v, expected %v", n, buf.Len())
+	}
+	if out.reliability != in.reliability {
+		t.Fatalf("reliability mismatch: got %v, expected %v", out.reliability, in.reliability)
+	}
+	if out.messageIndex != in.messageIndex {
+		t.Fatalf("message index mismatch: got %v, expected %v", out.messageIndex, in.messageIndex)
+	}
+	if out.orderIndex != in.orderIndex {
+		t.Fatalf("order index mismatch: got %v, expected %v", out.orderIndex, in.orderIndex)
+	}
+	if out.orderChannel != in.orderChannel {
+		t.Fatalf("order channel mismatch: got %v, expected %v", out.orderChannel, in.orderChannel)
+	}
+	if !bytes.Equal(out.content, in.content) {
+		t.Fatalf("content mismatch: got %x, expected %x", out.content, in.content)
+	}
+}
+
+func TestPacketChannelQueuePreservesChannelStateAfterDrain(t *testing.T) {
+	queue := newPacketChannelQueue()
+
+	if !queue.put(3, 0, []byte("x0")) {
+		t.Fatal("put channel 3 index 0 failed")
+	}
+	packets := queue.fetch(3)
+	if len(packets) != 1 || string(packets[0]) != "x0" {
+		t.Fatalf("expected only x0 for channel 3, got %q", packets)
+	}
+
+	// Duplicate of an already consumed packet must still be rejected.
+	if queue.put(3, 0, []byte("x0-dup")) {
+		t.Fatal("expected duplicate after drain to be rejected")
+	}
+
+	if !queue.put(3, 1, []byte("x1")) {
+		t.Fatal("put channel 3 index 1 failed")
+	}
+	packets = queue.fetch(3)
+	if len(packets) != 1 || string(packets[0]) != "x1" {
+		t.Fatalf("expected only x1 for channel 3, got %q", packets)
+	}
+}
+
+type recordingPacketConn struct {
+	writes [][]byte
+}
+
+func (conn *recordingPacketConn) ReadFrom(_ []byte) (n int, addr net.Addr, err error) {
+	return 0, nil, io.EOF
+}
+
+func (conn *recordingPacketConn) WriteTo(p []byte, _ net.Addr) (n int, err error) {
+	b := make([]byte, len(p))
+	copy(b, p)
+	conn.writes = append(conn.writes, b)
+	return len(p), nil
+}
+
+func (conn *recordingPacketConn) Close() error                       { return nil }
+func (conn *recordingPacketConn) LocalAddr() net.Addr                { return &net.UDPAddr{} }
+func (conn *recordingPacketConn) SetDeadline(_ time.Time) error      { return nil }
+func (conn *recordingPacketConn) SetReadDeadline(_ time.Time) error  { return nil }
+func (conn *recordingPacketConn) SetWriteDeadline(_ time.Time) error { return nil }
+
+func TestConnWriteUsesPerChannelOrderIndex(t *testing.T) {
+	wire := &recordingPacketConn{}
+	conn := &Conn{
+		conn:           wire,
+		raddr:          &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 19132},
+		mtu:            1400,
+		buf:            bytes.NewBuffer(make([]byte, 0, 1400-28)),
+		retransmission: newRecoveryQueue(),
+	}
+
+	if _, err := conn.write([]byte{0x01}, reliabilityReliableOrdered, 2); err != nil {
+		t.Fatalf("write packet 1: %v", err)
+	}
+	if _, err := conn.write([]byte{0x02}, reliabilityReliableOrdered, 2); err != nil {
+		t.Fatalf("write packet 2: %v", err)
+	}
+	if _, err := conn.write([]byte{0x03}, reliabilityReliableOrdered, 5); err != nil {
+		t.Fatalf("write packet 3: %v", err)
+	}
+
+	if len(wire.writes) != 3 {
+		t.Fatalf("expected 3 datagrams, got %v", len(wire.writes))
+	}
+
+	first := decodeDatagramPacket(t, wire.writes[0])
+	second := decodeDatagramPacket(t, wire.writes[1])
+	third := decodeDatagramPacket(t, wire.writes[2])
+
+	if first.orderChannel != 2 || first.orderIndex != 0 {
+		t.Fatalf("unexpected first packet order metadata: channel=%v index=%v", first.orderChannel, first.orderIndex)
+	}
+	if second.orderChannel != 2 || second.orderIndex != 1 {
+		t.Fatalf("unexpected second packet order metadata: channel=%v index=%v", second.orderChannel, second.orderIndex)
+	}
+	if third.orderChannel != 5 || third.orderIndex != 0 {
+		t.Fatalf("unexpected third packet order metadata: channel=%v index=%v", third.orderChannel, third.orderIndex)
+	}
+}
+
+func decodeDatagramPacket(t *testing.T, b []byte) packet {
+	t.Helper()
+
+	if len(b) < 4 {
+		t.Fatalf("invalid datagram length: %v", len(b))
+	}
+	if b[0]&bitFlagDatagram == 0 {
+		t.Fatalf("missing datagram bitflag: %x", b[0])
+	}
+
+	var pk packet
+	n, err := pk.read(b[4:])
+	if err != nil {
+		t.Fatalf("decode packet: %v", err)
+	}
+	if n != len(b)-4 {
+		t.Fatalf("decoded packet bytes mismatch: got %v, expected %v", n, len(b)-4)
+	}
+	return pk
+}

--- a/packet.go
+++ b/packet.go
@@ -79,6 +79,7 @@ type packet struct {
 	messageIndex  uint24
 	sequenceIndex uint24
 	orderIndex    uint24
+	orderChannel  byte
 
 	content []byte
 
@@ -105,8 +106,7 @@ func (pk *packet) write(buf *bytes.Buffer) {
 	}
 	if pk.reliability.sequencedOrOrdered() {
 		writeUint24(buf, pk.orderIndex)
-		// Order channel, we don't care about this.
-		buf.WriteByte(0)
+		buf.WriteByte(pk.orderChannel)
 	}
 	if pk.split {
 		writeUint32(buf, pk.splitCount)
@@ -124,6 +124,7 @@ func (pk *packet) read(b []byte) (int, error) {
 	header := b[0]
 	pk.split = (header & splitFlag) != 0
 	pk.reliability = reliability((header & 224) >> 5)
+	pk.orderChannel = 0
 
 	n := binary.BigEndian.Uint16(b[1:]) >> 3
 	if n == 0 {
@@ -152,7 +153,7 @@ func (pk *packet) read(b []byte) (int, error) {
 			return 0, io.ErrUnexpectedEOF
 		}
 		pk.orderIndex = loadUint24(b[offset:])
-		// Order channel (byte)
+		pk.orderChannel = b[offset+3]
 		offset += 4
 	}
 

--- a/packet_queue.go
+++ b/packet_queue.go
@@ -50,3 +50,64 @@ func (queue *packetQueue) fetch() (packets [][]byte) {
 func (queue *packetQueue) WindowSize() uint24 {
 	return queue.highest - queue.lowest
 }
+
+// packetChannelQueue keeps a packet queue for each ordering channel.
+type packetChannelQueue struct {
+	channels map[byte]*packetQueue
+}
+
+// newPacketChannelQueue returns a new initialised per-channel ordered queue.
+func newPacketChannelQueue() *packetChannelQueue {
+	return &packetChannelQueue{channels: make(map[byte]*packetQueue)}
+}
+
+// put stores a packet in the queue for an ordering channel. It returns false
+// if that packet index was already seen for the same channel.
+func (queue *packetChannelQueue) put(channel byte, index uint24, packet []byte) bool {
+	return queue.channel(channel).put(index, packet)
+}
+
+// fetch returns consecutive packets for the channel passed, starting at the
+// current lowest index for that channel.
+func (queue *packetChannelQueue) fetch(channel byte) [][]byte {
+	ch, ok := queue.channels[channel]
+	if !ok {
+		return nil
+	}
+	return ch.fetch()
+}
+
+// WindowSize returns the size of the queue window for a specific channel.
+func (queue *packetChannelQueue) WindowSize(channel byte) uint24 {
+	ch, ok := queue.channels[channel]
+	if !ok {
+		return 0
+	}
+	return ch.WindowSize()
+}
+
+// TotalWindowSize returns the total size of all channel queue windows.
+func (queue *packetChannelQueue) TotalWindowSize() (size uint24) {
+	for _, ch := range queue.channels {
+		size += ch.WindowSize()
+	}
+	return size
+}
+
+// WindowBounds returns the current low/high bounds of a channel queue.
+func (queue *packetChannelQueue) WindowBounds(channel byte) (lowest, highest uint24) {
+	ch, ok := queue.channels[channel]
+	if !ok {
+		return 0, 0
+	}
+	return ch.lowest, ch.highest
+}
+
+func (queue *packetChannelQueue) channel(channel byte) *packetQueue {
+	if ch, ok := queue.channels[channel]; ok {
+		return ch
+	}
+	ch := newPacketQueue()
+	queue.channels[channel] = ch
+	return ch
+}


### PR DESCRIPTION
## Summary

Add multi ordering-channel support to `go-raknet`, based on Cloudburst's RakNet ordering model.

## Cloudburst references

- Ordered receive path per channel 
[ RakSessionCodec.java#L371-L401 ](https://github.com/CloudburstMC/Network/blob/048658bf815119f91a3bd23ae35a77a4c4073af8/transport-raknet/src/main/java/org/cloudburstmc/netty/handler/codec/raknet/common/RakSessionCodec.java#L371-L401)

- Ordered send path per-channel write index + set ordering channel/index:  
[ RakSessionCodec.java#L726-L738 ](https://github.com/CloudburstMC/Network/blob/048658bf815119f91a3bd23ae35a77a4c4073af8/transport-raknet/src/main/java/org/cloudburstmc/netty/handler/codec/raknet/common/RakSessionCodec.java#L726-L738)
