### PR TITLE
dial.go: Add Dialer.MaxMTU to cap MTU on low-MTU paths

### DIFF
--- a/dial.go
+++ b/dial.go
@@ -97,6 +97,18 @@ type Dialer struct {
 	// UpstreamDialer is a dialer that will override the default dialer for
 	// opening outgoing connections. The default is a net.Dial("udp", ...).
 	UpstreamDialer UpstreamDialer
+
+	// MaxMTU caps the largest MTU value used during the connection
+	// handshake. The default (0) keeps the existing behaviour: probes start
+	// at 1492 bytes and the negotiated MTU may go up to 1500.
+	//
+	// Set this to your local interface MTU when it is below 1500 (for
+	// example 1400 on hosts behind a tunnel or VPN). With the default,
+	// the kernel will fragment the first probes into two IP packets, and
+	// some firewalls drop fragmented UDP and never deliver them to the
+	// server. Capping the MTU keeps every packet inside a single IP
+	// datagram for the entire connection.
+	MaxMTU uint16
 }
 
 // Ping sends a ping to an address and returns the response obtained. If
@@ -221,7 +233,7 @@ func (dialer Dialer) DialContext(ctx context.Context, address string) (*Conn, er
 	}
 	dialer.ErrorLog = dialer.ErrorLog.With("src", "dialer", "raddr", conn.RemoteAddr().String())
 
-	cs := &connState{conn: conn, raddr: conn.RemoteAddr(), id: atomic.AddInt64(&dialerID, 1), ticker: time.NewTicker(time.Second / 2)}
+	cs := &connState{conn: conn, raddr: conn.RemoteAddr(), id: atomic.AddInt64(&dialerID, 1), ticker: time.NewTicker(time.Second / 2), maxMTU: dialer.MaxMTU}
 	defer cs.ticker.Stop()
 	if err = cs.discoverMTU(ctx); err != nil {
 		return nil, dialer.error("dial", fmt.Errorf("discover mtu: %w", err))
@@ -286,6 +298,10 @@ type connState struct {
 	// 1 packet. It is the MTU size sent by the server.
 	mtu uint16
 
+	// maxMTU is copied from Dialer.MaxMTU and caps the probe sizes used
+	// during MTU discovery. Zero means use the defaults.
+	maxMTU uint16
+
 	serverSecurity bool
 	cookie         uint32
 
@@ -294,6 +310,26 @@ type connState struct {
 
 var mtuSizes = []uint16{1492, 1200, 576}
 
+// mtuSizesFor returns the MTU values to probe with when starting a
+// connection. If maxMTU is zero or already at least 1492, the unmodified
+// default list is returned. Otherwise the largest entry is replaced with
+// maxMTU and any default entries that are still smaller are kept after it.
+func mtuSizesFor(maxMTU uint16) []uint16 {
+	if maxMTU == 0 || maxMTU >= 1492 {
+		return mtuSizes
+	}
+	if maxMTU < 576 {
+		return []uint16{maxMTU}
+	}
+	out := []uint16{maxMTU}
+	for _, s := range mtuSizes {
+		if s < maxMTU {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
 // discoverMTU starts discovering an MTU size, the maximum packet size we
 // can send, by sending multiple open connection request 1 packets to the
 // server with a decreasing MTU size padding.
@@ -301,7 +337,7 @@ func (state *connState) discoverMTU(ctx context.Context) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	go state.request1(ctx, mtuSizes)
+	go state.request1(ctx, mtuSizesFor(state.maxMTU))
 
 	b := make([]byte, 1492)
 	for {


### PR DESCRIPTION
## Problem

The dialer always starts MTU discovery at 1492 bytes. On hosts where
the local interface MTU is below 1500 (VPN, tunnel, some VPS providers)
the kernel fragments those first probes into two IP packets. Several
anti-DDoS layers in front of Bedrock servers drop fragmented UDP, so
the probe never reaches the origin and the dial times out.

I hit this on a host with eth0 MTU 1400. Vanilla Bedrock connected
fine on a normal 1500 MTU network, the Go dial against the same
servers timed out at MTU discovery.

## Change

New `Dialer.MaxMTU` field. When set, the probe sizes are capped so
each probe fits in a single IP datagram on the local path. Default
(0) keeps the existing behaviour unchanged.

## Test

Side by side capture on the same host (`eth0 mtu 1400`) dialing the
same Bedrock server. Source IP and server IP redacted as `x.x.x.x`
and `y.y.y.y`.

**Default (probe 1492):** four fragmented probes, no replies, the
dial only succeeds after the fallback to the 1200-byte probe.
Connect time: 2.038s.

15:44:43.612305 Out IP x.x.x.x.32771 > y.y.y.y.19132: UDP, length 1464
15:44:43.612325 Out IP x.x.x.x > y.y.y.y: ip-proto-17
15:44:44.113208 Out IP x.x.x.x.32771 > y.y.y.y.19132: UDP, length 1464
15:44:44.113222 Out IP x.x.x.x > y.y.y.y: ip-proto-17
15:44:44.613251 Out IP x.x.x.x.32771 > y.y.y.y.19132: UDP, length 1464
15:44:44.613266 Out IP x.x.x.x > y.y.y.y: ip-proto-17
15:44:45.113161 Out IP x.x.x.x.32771 > y.y.y.y.19132: UDP, length 1464
15:44:45.113175 Out IP x.x.x.x > y.y.y.y: ip-proto-17
15:44:45.613219 Out IP x.x.x.x.32771 > y.y.y.y.19132: UDP, length 1172
15:44:45.630039 In  IP y.y.y.y.19132 > x.x.x.x.32771: UDP, length 32
15:44:45.630040 In  IP y.y.y.y.19132 > x.x.x.x.32771: UDP, length 35



The `ip-proto-17` lines are the second IP fragment, no UDP header on
them. Each pair adds up to the 1492-byte probe split across the
1400-byte MTU. None of the four pairs gets a reply.

**With `MaxMTU: 1400` (probe 1400):** first probe already fits in a
single IP packet, reply arrives 16ms later. Connect time: 39ms.

15:44:55.684186 Out IP x.x.x.x.37467 > y.y.y.y.19132: UDP, length 1372
15:44:55.700777 In  IP y.y.y.y.19132 > x.x.x.x.37467: UDP, length 32
15:44:55.700834 In  IP y.y.y.y.19132 > x.x.x.x.37467: UDP, length 35
15:44:55.701047 Out IP x.x.x.x.37467 > y.y.y.y.19132: UDP, length 32
15:44:55.701109 Out IP x.x.x.x.37467 > y.y.y.y.19132: UDP, length 39
15:44:55.717608 In  IP y.y.y.y.19132 > x.x.x.x.37467: UDP, length 180



On servers where the fragmented fallback is also dropped the default
times out completely, `MaxMTU` connects in well under a second.