### PR TITLE
dial.go: Add Dialer.MaxMTU to cap MTU on low-MTU paths

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -97,7 +97,7 @@ type Conn struct {
 // newConn constructs a new connection specifically dedicated to the address
 // passed.
 func newConn(conn net.PacketConn, raddr net.Addr, mtu uint16, h connectionHandler) *Conn {
-	mtu = min(max(mtu, minMTUSize), maxMTUSize)
+	mtu = clampMTU(mtu, minMTUSize)
 	c := &Conn{
 		raddr:          raddr,
 		conn:           conn,
@@ -119,6 +119,14 @@ func newConn(conn net.PacketConn, raddr net.Addr, mtu uint16, h connectionHandle
 	c.lastActivity.Store(&t)
 	go c.startTicking()
 	return c
+}
+
+// clampMTU bounds mtu to the supported range.
+func clampMTU(mtu, minMTU uint16) uint16 {
+	if mtu == 0 || mtu > maxMTUSize {
+		return maxMTUSize
+	}
+	return max(mtu, minMTU)
 }
 
 // effectiveMTU returns the mtu size without the space allocated for IP and

--- a/dial.go
+++ b/dial.go
@@ -105,6 +105,18 @@ type Dialer struct {
 	// Default is 10. -1 means no limit.
 	// This is only used for the initial connection handshake.
 	MaxTransientErrors int
+
+	// MaxMTU caps the largest MTU value used during the connection
+	// handshake. The default (0) keeps the existing behaviour: probes start
+	// at 1492 bytes and the negotiated MTU may go up to 1500.
+	//
+	// Set this to your local interface MTU when it is below 1500 (for
+	// example 1400 on hosts behind a tunnel or VPN). With the default,
+	// the kernel will fragment the first probes into two IP packets, and
+	// some firewalls drop fragmented UDP and never deliver them to the
+	// server. Capping the MTU keeps every packet inside a single IP
+	// datagram for the entire connection.
+	MaxMTU uint16
 }
 
 // Ping sends a ping to an address and returns the response obtained. If
@@ -239,6 +251,7 @@ func (dialer Dialer) DialContext(ctx context.Context, address string) (*Conn, er
 		id:                 atomic.AddInt64(&dialerID, 1),
 		ticker:             time.NewTicker(time.Second / 2),
 		maxTransientErrors: dialer.MaxTransientErrors,
+		maxMTU:             dialer.MaxMTU,
 	}
 	defer cs.ticker.Stop()
 	if err = cs.discoverMTU(ctx); err != nil {
@@ -303,6 +316,10 @@ type connState struct {
 	// 1 packet. It is the MTU size sent by the server.
 	mtu uint16
 
+	// maxMTU is copied from Dialer.MaxMTU and caps the probe sizes used
+	// during MTU discovery. Zero means use the defaults.
+	maxMTU uint16
+
 	serverSecurity bool
 	cookie         uint32
 
@@ -314,6 +331,26 @@ type connState struct {
 
 var mtuSizes = []uint16{1492, 1200, 576}
 
+// mtuSizesFor returns the MTU values to probe with when starting a
+// connection. If maxMTU is zero or already at least 1492, the unmodified
+// default list is returned. Otherwise the largest entry is replaced with
+// maxMTU and any default entries that are still smaller are kept after it.
+func mtuSizesFor(maxMTU uint16) []uint16 {
+	if maxMTU == 0 || maxMTU >= 1492 {
+		return mtuSizes
+	}
+	if maxMTU < 576 {
+		return []uint16{maxMTU}
+	}
+	out := []uint16{maxMTU}
+	for _, s := range mtuSizes {
+		if s < maxMTU {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
 // discoverMTU starts discovering an MTU size, the maximum packet size we
 // can send, by sending multiple open connection request 1 packets to the
 // server with a decreasing MTU size padding.
@@ -321,7 +358,7 @@ func (state *connState) discoverMTU(ctx context.Context) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	go state.request1(ctx, mtuSizes)
+	go state.request1(ctx, mtuSizesFor(state.maxMTU))
 
 	b := make([]byte, 1492)
 	for {

--- a/dial.go
+++ b/dial.go
@@ -107,8 +107,7 @@ type Dialer struct {
 	MaxTransientErrors int
 
 	// MaxMTU caps the largest MTU value used during the connection
-	// handshake. The default (0) keeps the existing behaviour: probes start
-	// at 1492 bytes and the negotiated MTU may go up to 1500.
+	// handshake. If zero, probes start at the maximum supported MTU.
 	//
 	// Set this to your local interface MTU when it is below 1500 (for
 	// example 1400 on hosts behind a tunnel or VPN). With the default,
@@ -162,7 +161,7 @@ func (dialer Dialer) PingContext(ctx context.Context, address string) (response 
 		return nil, dialer.error("ping", err)
 	}
 
-	data = make([]byte, 1492)
+	data = make([]byte, maxMTUSize)
 	n, err := conn.Read(data)
 	if err != nil {
 		return nil, dialer.error("ping", err)
@@ -329,18 +328,19 @@ type connState struct {
 	maxTransientErrors  int
 }
 
-var mtuSizes = []uint16{1492, 1200, 576}
+const minSupportedMTU = 576
+
+// mtuSizes is the default probe sequence used for MTU discovery.
+var mtuSizes = []uint16{maxMTUSize, 1200, minSupportedMTU}
 
 // mtuSizesFor returns the MTU values to probe with when starting a
-// connection. If maxMTU is zero or already at least 1492, the unmodified
+// connection. If maxMTU is zero or already at least maxMTUSize, the unmodified
 // default list is returned. Otherwise the largest entry is replaced with
 // maxMTU and any default entries that are still smaller are kept after it.
 func mtuSizesFor(maxMTU uint16) []uint16 {
-	if maxMTU == 0 || maxMTU >= 1492 {
+	maxMTU = clampMTU(maxMTU, minSupportedMTU)
+	if maxMTU == maxMTUSize {
 		return mtuSizes
-	}
-	if maxMTU < 576 {
-		return []uint16{maxMTU}
 	}
 	out := []uint16{maxMTU}
 	for _, s := range mtuSizes {
@@ -360,7 +360,7 @@ func (state *connState) discoverMTU(ctx context.Context) error {
 
 	go state.request1(ctx, mtuSizesFor(state.maxMTU))
 
-	b := make([]byte, 1492)
+	b := make([]byte, maxMTUSize)
 	for {
 		// Start reading in a loop so that we can find an open connection reply
 		// 1 packet.
@@ -428,7 +428,7 @@ func (state *connState) openConnection(ctx context.Context) error {
 
 	go state.request2(ctx, state.mtu)
 
-	b := make([]byte, 1492)
+	b := make([]byte, maxMTUSize)
 	for {
 		// Start reading in a loop so that we can find open connection reply 2
 		// packets.

--- a/handler.go
+++ b/handler.go
@@ -98,7 +98,7 @@ func (h listenerConnectionHandler) handleOpenConnectionRequest1(b []byte, addr n
 	if err := pk.UnmarshalBinary(b); err != nil {
 		return fmt.Errorf("read OPEN_CONNECTION_REQUEST_1: %w", err)
 	}
-	mtuSize := min(pk.MTU, maxMTUSize)
+	mtuSize := min(pk.MTU, h.l.maxMTU())
 
 	if pk.ClientProtocol != protocolVersion {
 		data, _ := (&message.IncompatibleProtocolVersion{ServerGUID: h.l.id, ServerProtocol: protocolVersion}).MarshalBinary()
@@ -128,7 +128,7 @@ func (h listenerConnectionHandler) handleOpenConnectionRequest2(b []byte, addr n
 		return fmt.Errorf("handle OPEN_CONNECTION_REQUEST_2: invalid ClientGUID '%d', expected negative", pk.ClientGUID)
 	}
 
-	mtuSize := min(pk.MTU, maxMTUSize)
+	mtuSize := min(pk.MTU, h.l.maxMTU())
 
 	data, _ := (&message.OpenConnectionReply2{ServerGUID: h.l.id, ClientAddress: resolve(addr), MTU: mtuSize}).MarshalBinary()
 	if _, err := h.l.conn.WriteTo(data, addr); err != nil {

--- a/listener.go
+++ b/listener.go
@@ -36,6 +36,9 @@ type ListenConfig struct {
 	// systems that interfere with this. In this case, DisableCookies should be
 	// set to true.
 	DisableCookies bool
+	// MaxMTU caps the largest MTU negotiated with incoming clients. If zero,
+	// the maximum supported MTU is used.
+	MaxMTU uint16
 	// BlockDuration specifies how long IP addresses should be blocked if an
 	// error is encountered during the handling of packets from an address.
 	// BlockDuration defaults to 10s. If set to a negative value, IP addresses
@@ -89,6 +92,7 @@ func (conf ListenConfig) Listen(address string) (*Listener, error) {
 	if conf.BlockDuration == 0 {
 		conf.BlockDuration = time.Second * 10
 	}
+	conf.MaxMTU = clampMTU(conf.MaxMTU, minMTUSize)
 	var conn net.PacketConn
 	var err error
 
@@ -175,6 +179,11 @@ func (listener *Listener) PongData(data []byte) {
 // client to identify a specific server during a single session.
 func (listener *Listener) ID() int64 {
 	return listener.id
+}
+
+// maxMTU returns the listener's effective negotiated MTU cap.
+func (listener *Listener) maxMTU() uint16 {
+	return clampMTU(listener.conf.MaxMTU, minMTUSize)
 }
 
 // listen continuously reads from the listener's UDP connection, until closed


### PR DESCRIPTION
## Problem

The dialer always starts MTU discovery at 1492 bytes. On hosts where
the local interface MTU is below 1500 (VPN, tunnel, some VPS providers)
the kernel fragments those first probes into two IP packets. Several
anti-DDoS layers in front of Bedrock servers drop fragmented UDP, so
the probe never reaches the origin and the dial times out.

I hit this on a host with eth0 MTU 1400. Vanilla Bedrock connected
fine on a normal 1500 MTU network, the Go dial against the same
servers timed out at MTU discovery.

## Change

New `Dialer.MaxMTU` field. When set, the probe sizes are capped so
each probe fits in a single IP datagram on the local path. Default
(0) keeps the existing behaviour unchanged.

## Test

Side by side capture on the same host (`eth0 mtu 1400`) dialing the
same Bedrock server. Source IP and server IP redacted as `x.x.x.x`
and `y.y.y.y`.

**Default (probe 1492):** four fragmented probes, no replies, the
dial only succeeds after the fallback to the 1200-byte probe.
Connect time: 2.038s.

15:44:43.612305 Out IP x.x.x.x.32771 > y.y.y.y.19132: UDP, length 1464
15:44:43.612325 Out IP x.x.x.x > y.y.y.y: ip-proto-17
15:44:44.113208 Out IP x.x.x.x.32771 > y.y.y.y.19132: UDP, length 1464
15:44:44.113222 Out IP x.x.x.x > y.y.y.y: ip-proto-17
15:44:44.613251 Out IP x.x.x.x.32771 > y.y.y.y.19132: UDP, length 1464
15:44:44.613266 Out IP x.x.x.x > y.y.y.y: ip-proto-17
15:44:45.113161 Out IP x.x.x.x.32771 > y.y.y.y.19132: UDP, length 1464
15:44:45.113175 Out IP x.x.x.x > y.y.y.y: ip-proto-17
15:44:45.613219 Out IP x.x.x.x.32771 > y.y.y.y.19132: UDP, length 1172
15:44:45.630039 In  IP y.y.y.y.19132 > x.x.x.x.32771: UDP, length 32
15:44:45.630040 In  IP y.y.y.y.19132 > x.x.x.x.32771: UDP, length 35



The `ip-proto-17` lines are the second IP fragment, no UDP header on
them. Each pair adds up to the 1492-byte probe split across the
1400-byte MTU. None of the four pairs gets a reply.

**With `MaxMTU: 1400` (probe 1400):** first probe already fits in a
single IP packet, reply arrives 16ms later. Connect time: 39ms.

15:44:55.684186 Out IP x.x.x.x.37467 > y.y.y.y.19132: UDP, length 1372
15:44:55.700777 In  IP y.y.y.y.19132 > x.x.x.x.37467: UDP, length 32
15:44:55.700834 In  IP y.y.y.y.19132 > x.x.x.x.37467: UDP, length 35
15:44:55.701047 Out IP x.x.x.x.37467 > y.y.y.y.19132: UDP, length 32
15:44:55.701109 Out IP x.x.x.x.37467 > y.y.y.y.19132: UDP, length 39
15:44:55.717608 In  IP y.y.y.y.19132 > x.x.x.x.37467: UDP, length 180



On servers where the fragmented fallback is also dropped the default
times out completely, `MaxMTU` connects in well under a second