### PR TITLE
Guard address type assertions

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -56,8 +56,7 @@ func (h listenerConnectionHandler) cookie(addr net.Addr, salt uint64) uint32 {
 		binary.LittleEndian.PutUint16(b[8:], uint16(udp.Port))
 		b = append(b, udp.IP...)
 	} else if addr != nil {
-		// Non-UDP address (custom listener): hash its string form so cookies
-		// stay deterministic per address instead of dereferencing a nil *UDPAddr.
+		// Hash custom address strings to keep cookies deterministic.
 		b = append(b, addr.String()...)
 	}
 	// CRC32 isn't cryptographically secure, but we don't really need that here.

--- a/handler.go
+++ b/handler.go
@@ -50,11 +50,16 @@ func (h listenerConnectionHandler) cookie(addr net.Addr, salt uint64) uint32 {
 	if h.l.conf.DisableCookies {
 		return 0
 	}
-	udp, _ := addr.(*net.UDPAddr)
 	b := make([]byte, 10, 26)
 	binary.LittleEndian.PutUint64(b, salt)
-	binary.LittleEndian.PutUint16(b[8:], uint16(udp.Port))
-	b = append(b, udp.IP...)
+	if udp, ok := addr.(*net.UDPAddr); ok && udp != nil {
+		binary.LittleEndian.PutUint16(b[8:], uint16(udp.Port))
+		b = append(b, udp.IP...)
+	} else if addr != nil {
+		// Non-UDP address (custom listener): hash its string form so cookies
+		// stay deterministic per address instead of dereferencing a nil *UDPAddr.
+		b = append(b, addr.String()...)
+	}
 	// CRC32 isn't cryptographically secure, but we don't really need that here.
 	// A new salt is calculated every time a Listener is created and we don't
 	// have any data that needs to protected. We just need a fast hash.

--- a/listener.go
+++ b/listener.go
@@ -302,10 +302,7 @@ func (s *security) tick(stop <-chan struct{}) {
 	}
 }
 
-// addrIPKey returns the 16-byte IP used as a block-map key for addr. It reports
-// false when addr is not a *net.UDPAddr or carries an IP that does not resolve
-// to a 16-byte form, so callers can treat such addresses as unblockable instead
-// of panicking.
+// addrIPKey returns addr's 16-byte IP address, if available.
 func addrIPKey(addr net.Addr) ([16]byte, bool) {
 	udp, ok := addr.(*net.UDPAddr)
 	if !ok || udp == nil {
@@ -330,8 +327,7 @@ func (s *security) blockFor(addr net.Addr, duration time.Duration) {
 	}
 	ip, ok := addrIPKey(addr)
 	if !ok {
-		// Addresses without a resolvable IP (non-UDP listeners, malformed IPs)
-		// are unblockable rather than a panic.
+		// Ignore addresses that cannot be blocked by IP.
 		return
 	}
 	s.mu.Lock()

--- a/listener.go
+++ b/listener.go
@@ -302,6 +302,22 @@ func (s *security) tick(stop <-chan struct{}) {
 	}
 }
 
+// addrIPKey returns the 16-byte IP used as a block-map key for addr. It reports
+// false when addr is not a *net.UDPAddr or carries an IP that does not resolve
+// to a 16-byte form, so callers can treat such addresses as unblockable instead
+// of panicking.
+func addrIPKey(addr net.Addr) ([16]byte, bool) {
+	udp, ok := addr.(*net.UDPAddr)
+	if !ok || udp == nil {
+		return [16]byte{}, false
+	}
+	ip := udp.IP.To16()
+	if ip == nil {
+		return [16]byte{}, false
+	}
+	return [16]byte(ip), true
+}
+
 // block stops the handling of packets originating from the IP of a net.Addr for the duration provided by the ListenConfig.
 func (s *security) block(addr net.Addr) {
 	s.blockFor(addr, s.conf.BlockDuration)
@@ -312,11 +328,15 @@ func (s *security) blockFor(addr net.Addr, duration time.Duration) {
 	if duration <= 0 {
 		return
 	}
+	ip, ok := addrIPKey(addr)
+	if !ok {
+		// Addresses without a resolvable IP (non-UDP listeners, malformed IPs)
+		// are unblockable rather than a panic.
+		return
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	ip := [16]byte(addr.(*net.UDPAddr).IP.To16())
-	
 	if _, ok := s.blocks[ip]; !ok {
 		s.blockCount.Add(1)
 	}
@@ -331,10 +351,12 @@ func (s *security) blocked(addr net.Addr) bool {
 		// Fast path optimisation: Prevents (relatively costly) map lookups.
 		return false
 	}
+	ip, ok := addrIPKey(addr)
+	if !ok {
+		return false
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-
-	ip := [16]byte(addr.(*net.UDPAddr).IP.To16())
 
 	expiresAt, blocked := s.blocks[ip]
 	if !blocked {
@@ -345,7 +367,7 @@ func (s *security) blocked(addr net.Addr) bool {
 		s.blockCount.Store(uint32(len(s.blocks)))
 		return false
 	}
-	
+
 	return true
 }
 


### PR DESCRIPTION
## What changed

- Guard cookie generation against non-UDP, nil, and typed-nil addresses.
- Extract UDP IP block-map keys safely and treat addresses without a valid IP as unblockable.
- Avoid panics when a custom packet listener returns an unexpected address type.

## Why

ListenConfig supports custom packet listeners, but the cookie and security paths asserted every address to `*net.UDPAddr`. An unexpected or malformed address could therefore panic the listener instead of being handled safely.
