### PR TITLE
Harden malformed packet handling and split reassembly

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -35,6 +35,9 @@ const (
 	// splitTimeout is how long a reassembly may go without a new fragment
 	// before its slot may be reclaimed. The client uses its connection timeout.
 	splitTimeout = time.Second * 10
+	// splitSweepInterval bounds how often arriving at the cap may sweep, so a
+	// peer cannot make every fragment it sends scan the whole reassembly map.
+	splitSweepInterval = time.Second
 )
 
 // splitEntry is a packet part way through reassembly. Fragments are positioned
@@ -86,6 +89,8 @@ type Conn struct {
 	// slices is equal to the split count, and packets are positioned in that
 	// slice indexed by the split index.
 	splits map[uint16]splitEntry
+	// lastSplitSweep is when splits was last swept for expired reassemblies.
+	lastSplitSweep time.Time
 
 	// win is an ordered queue used to track which datagrams were received and
 	// which datagrams were missing, so that we can send NACKs to request
@@ -568,8 +573,9 @@ func (conn *Conn) receiveSplitPacket(p *packet) error {
 		return nil
 	}
 	if !ok {
-		if len(conn.splits) >= maxConcurrentSplits {
-			conn.evictExpiredSplits(time.Now())
+		if now := time.Now(); len(conn.splits) >= maxConcurrentSplits && now.Sub(conn.lastSplitSweep) >= splitSweepInterval {
+			conn.lastSplitSweep = now
+			conn.evictExpiredSplits(now)
 		}
 		if len(conn.splits) >= maxConcurrentSplits {
 			// Drop the fragment starting a new packet, never one already part
@@ -603,7 +609,8 @@ func (conn *Conn) receiveSplitPacket(p *packet) error {
 
 // evictExpiredSplits frees reassemblies that have not advanced within
 // splitTimeout, so a peer cannot hold every slot for the rest of the session.
-// The client sweeps its own split list the same way on each update.
+// The client sweeps on every update; this runs only under slot pressure, which
+// reclaims the same slots at the point they are wanted.
 func (conn *Conn) evictExpiredSplits(now time.Time) {
 	for id, entry := range conn.splits {
 		if now.Sub(entry.lastUpdate) >= splitTimeout {

--- a/conn.go
+++ b/conn.go
@@ -27,7 +27,7 @@ const (
 	maxMTUSize    = 1492
 	maxWindowSize = 2048
 
-	// Split reassembly limits bound peer-controlled allocations on every connection.
+	// Split reassembly limits bound memory use on every connection.
 	maxSplitCount       = 8192
 	maxConcurrentSplits = 256
 )
@@ -543,15 +543,13 @@ func resolve(addr net.Addr) netip.AddrPort {
 // packet of its sequence, it will continue handling the full packet as it
 // otherwise would. An error is returned if the packet was not valid.
 func (conn *Conn) receiveSplitPacket(p *packet) error {
-	// Unconditional memory-safety ceiling on peer-controlled values, enforced
-	// on every connection. This bounds the make([][]byte, splitCount)
-	// allocation below.
+	// Reject invalid split counts before allocating the fragment slice.
 	if p.splitCount == 0 || p.splitCount > maxSplitCount {
 		return fmt.Errorf("split packet: split count %v is out of range (1 - %v)", p.splitCount, maxSplitCount)
 	}
 	m, ok := conn.splits[p.splitID]
 	if !ok {
-		conn.evictSplitRingCollision(p.splitID)
+		conn.evictConflictingSplit(p.splitID)
 		m = make([][]byte, p.splitCount)
 		conn.splits[p.splitID] = m
 	}
@@ -574,8 +572,9 @@ func (conn *Conn) receiveSplitPacket(p *packet) error {
 	return conn.receivePacket(p)
 }
 
-// evictSplitRingCollision evicts stale state that shares a split ID slot.
-func (conn *Conn) evictSplitRingCollision(splitID uint16) {
+// evictConflictingSplit removes an incomplete split packet that occupies the
+// same bounded reassembly slot as splitID.
+func (conn *Conn) evictConflictingSplit(splitID uint16) {
 	slot := splitID % maxConcurrentSplits
 	for id := range conn.splits {
 		if id%maxConcurrentSplits == slot {

--- a/conn.go
+++ b/conn.go
@@ -560,6 +560,11 @@ func (conn *Conn) receiveSplitPacket(p *packet) error {
 		return fmt.Errorf("split packet: split count %v is out of range (1 - %v)", p.splitCount, maxSplitCount)
 	}
 	entry, ok := conn.splits[p.splitID]
+	if ok && int(p.splitCount) != len(entry.fragments) {
+		// The split count disagrees with the reassembly already under way for
+		// this ID, so the fragment belongs to neither. The client drops it.
+		return nil
+	}
 	if !ok {
 		if len(conn.splits) >= maxConcurrentSplits {
 			conn.evictExpiredSplits(time.Now())

--- a/conn.go
+++ b/conn.go
@@ -38,9 +38,11 @@ const (
 )
 
 // splitEntry is a packet part way through reassembly. Fragments are positioned
-// by split index, and lastUpdate is when the most recent one arrived.
+// by split index, received counts how many have arrived, and lastUpdate is when
+// the most recent one did.
 type splitEntry struct {
 	fragments  [][]byte
+	received   uint32
 	lastUpdate time.Time
 }
 
@@ -584,10 +586,11 @@ func (conn *Conn) receiveSplitPacket(p *packet) error {
 		return nil
 	}
 	entry.fragments[p.splitIndex] = p.content
+	entry.received++
 	entry.lastUpdate = time.Now()
 	conn.splits[p.splitID] = entry
 
-	if slices.ContainsFunc(entry.fragments, func(i []byte) bool { return i == nil }) {
+	if entry.received != uint32(len(entry.fragments)) {
 		// We haven't yet received all split fragments, so we cannot add the
 		// packets together yet.
 		return nil

--- a/conn.go
+++ b/conn.go
@@ -26,6 +26,10 @@ const (
 	minMTUSize    = 400
 	maxMTUSize    = 1492
 	maxWindowSize = 2048
+
+	// Split reassembly limits bound peer-controlled allocations on every connection.
+	maxSplitCount       = 8192
+	maxConcurrentSplits = 256
 )
 
 // Conn represents a connection to a specific client. It is not a real
@@ -539,28 +543,27 @@ func resolve(addr net.Addr) netip.AddrPort {
 // packet of its sequence, it will continue handling the full packet as it
 // otherwise would. An error is returned if the packet was not valid.
 func (conn *Conn) receiveSplitPacket(p *packet) error {
-	const maxSplitCount = 512
-	const maxConcurrentSplits = 16
-
-	if p.splitCount > maxSplitCount && conn.handler.limitsEnabled() {
-		return fmt.Errorf("split packet: split count %v exceeds the maximum %v", p.splitCount, maxSplitCount)
-	}
-	if len(conn.splits) > maxConcurrentSplits && conn.handler.limitsEnabled() {
-		return fmt.Errorf("split packet: maximum concurrent splits %v reached", maxConcurrentSplits)
+	// Unconditional memory-safety ceiling on peer-controlled values, enforced
+	// on every connection. This bounds the make([][]byte, splitCount)
+	// allocation below.
+	if p.splitCount == 0 || p.splitCount > maxSplitCount {
+		return fmt.Errorf("split packet: split count %v is out of range (1 - %v)", p.splitCount, maxSplitCount)
 	}
 	m, ok := conn.splits[p.splitID]
 	if !ok {
+		conn.evictSplitRingCollision(p.splitID)
 		m = make([][]byte, p.splitCount)
 		conn.splits[p.splitID] = m
 	}
 	if p.splitIndex > uint32(len(m)-1) {
-		// The split index was either negative or was bigger than the slice
-		// size, meaning the packet is invalid.
 		return fmt.Errorf("split packet: split index %v is out of range (0 - %v)", p.splitIndex, len(m)-1)
+	}
+	if m[p.splitIndex] != nil {
+		return nil
 	}
 	m[p.splitIndex] = p.content
 
-	if slices.ContainsFunc(m, func(i []byte) bool { return len(i) == 0 }) {
+	if slices.ContainsFunc(m, func(i []byte) bool { return i == nil }) {
 		// We haven't yet received all split fragments, so we cannot add the
 		// packets together yet.
 		return nil
@@ -569,6 +572,17 @@ func (conn *Conn) receiveSplitPacket(p *packet) error {
 
 	delete(conn.splits, p.splitID)
 	return conn.receivePacket(p)
+}
+
+// evictSplitRingCollision evicts stale state that shares a split ID slot.
+func (conn *Conn) evictSplitRingCollision(splitID uint16) {
+	slot := splitID % maxConcurrentSplits
+	for id := range conn.splits {
+		if id%maxConcurrentSplits == slot {
+			delete(conn.splits, id)
+			return
+		}
+	}
 }
 
 // sendACK sends an acknowledgement packet containing the packet sequence

--- a/conn.go
+++ b/conn.go
@@ -32,7 +32,17 @@ const (
 	// maxConcurrentSplits bounds packets part way through reassembly, matching
 	// the client, which drops fragments that would start a further one.
 	maxConcurrentSplits = 256
+	// splitTimeout is how long a reassembly may go without a new fragment
+	// before its slot may be reclaimed. The client uses its connection timeout.
+	splitTimeout = time.Second * 10
 )
+
+// splitEntry is a packet part way through reassembly. Fragments are positioned
+// by split index, and lastUpdate is when the most recent one arrived.
+type splitEntry struct {
+	fragments  [][]byte
+	lastUpdate time.Time
+}
 
 // Conn represents a connection to a specific client. It is not a real
 // connection, as UDP is connectionless, but rather a connection emulated using
@@ -73,7 +83,7 @@ type Conn struct {
 	// splits is a map of slices indexed by split IDs. The length of each of the
 	// slices is equal to the split count, and packets are positioned in that
 	// slice indexed by the split index.
-	splits map[uint16][][]byte
+	splits map[uint16]splitEntry
 
 	// win is an ordered queue used to track which datagrams were received and
 	// which datagrams were missing, so that we can send NACKs to request
@@ -112,7 +122,7 @@ func newConn(conn net.PacketConn, raddr net.Addr, mtu uint16, h connectionHandle
 		pk:             new(packet),
 		connected:      make(chan struct{}),
 		packets:        internal.Chan[[]byte](4, 4096),
-		splits:         make(map[uint16][][]byte),
+		splits:         make(map[uint16]splitEntry),
 		win:            newDatagramWindow(),
 		packetQueue:    newPacketQueue(),
 		retransmission: newRecoveryQueue(),
@@ -549,34 +559,49 @@ func (conn *Conn) receiveSplitPacket(p *packet) error {
 	if p.splitCount == 0 || p.splitCount > maxSplitCount {
 		return fmt.Errorf("split packet: split count %v is out of range (1 - %v)", p.splitCount, maxSplitCount)
 	}
-	m, ok := conn.splits[p.splitID]
+	entry, ok := conn.splits[p.splitID]
 	if !ok {
+		if len(conn.splits) >= maxConcurrentSplits {
+			conn.evictExpiredSplits(time.Now())
+		}
 		if len(conn.splits) >= maxConcurrentSplits {
 			// Drop the fragment starting a new packet, never one already part
 			// reassembled: its fragments are acknowledged, so the sender will
 			// not send them again.
 			return nil
 		}
-		m = make([][]byte, p.splitCount)
-		conn.splits[p.splitID] = m
+		entry.fragments = make([][]byte, p.splitCount)
 	}
-	if p.splitIndex > uint32(len(m)-1) {
-		return fmt.Errorf("split packet: split index %v is out of range (0 - %v)", p.splitIndex, len(m)-1)
+	if p.splitIndex > uint32(len(entry.fragments)-1) {
+		return fmt.Errorf("split packet: split index %v is out of range (0 - %v)", p.splitIndex, len(entry.fragments)-1)
 	}
-	if m[p.splitIndex] != nil {
+	if entry.fragments[p.splitIndex] != nil {
 		return nil
 	}
-	m[p.splitIndex] = p.content
+	entry.fragments[p.splitIndex] = p.content
+	entry.lastUpdate = time.Now()
+	conn.splits[p.splitID] = entry
 
-	if slices.ContainsFunc(m, func(i []byte) bool { return i == nil }) {
+	if slices.ContainsFunc(entry.fragments, func(i []byte) bool { return i == nil }) {
 		// We haven't yet received all split fragments, so we cannot add the
 		// packets together yet.
 		return nil
 	}
-	p.content = slices.Concat(m...)
+	p.content = slices.Concat(entry.fragments...)
 
 	delete(conn.splits, p.splitID)
 	return conn.receivePacket(p)
+}
+
+// evictExpiredSplits frees reassemblies that have not advanced within
+// splitTimeout, so a peer cannot hold every slot for the rest of the session.
+// The client sweeps its own split list the same way on each update.
+func (conn *Conn) evictExpiredSplits(now time.Time) {
+	for id, entry := range conn.splits {
+		if now.Sub(entry.lastUpdate) >= splitTimeout {
+			delete(conn.splits, id)
+		}
+	}
 }
 
 // sendACK sends an acknowledgement packet containing the packet sequence

--- a/conn.go
+++ b/conn.go
@@ -28,7 +28,9 @@ const (
 	maxWindowSize = 2048
 
 	// Split reassembly limits bound memory use on every connection.
-	maxSplitCount       = 8192
+	maxSplitCount = 8192
+	// maxConcurrentSplits bounds packets part way through reassembly, matching
+	// the client, which drops fragments that would start a further one.
 	maxConcurrentSplits = 256
 )
 
@@ -549,7 +551,12 @@ func (conn *Conn) receiveSplitPacket(p *packet) error {
 	}
 	m, ok := conn.splits[p.splitID]
 	if !ok {
-		conn.evictConflictingSplit(p.splitID)
+		if len(conn.splits) >= maxConcurrentSplits {
+			// Drop the fragment starting a new packet, never one already part
+			// reassembled: its fragments are acknowledged, so the sender will
+			// not send them again.
+			return nil
+		}
 		m = make([][]byte, p.splitCount)
 		conn.splits[p.splitID] = m
 	}
@@ -570,18 +577,6 @@ func (conn *Conn) receiveSplitPacket(p *packet) error {
 
 	delete(conn.splits, p.splitID)
 	return conn.receivePacket(p)
-}
-
-// evictConflictingSplit removes an incomplete split packet that occupies the
-// same bounded reassembly slot as splitID.
-func (conn *Conn) evictConflictingSplit(splitID uint16) {
-	slot := splitID % maxConcurrentSplits
-	for id := range conn.splits {
-		if id%maxConcurrentSplits == slot {
-			delete(conn.splits, id)
-			return
-		}
-	}
 }
 
 // sendACK sends an acknowledgement packet containing the packet sequence

--- a/internal/message/connection_request_accepted.go
+++ b/internal/message/connection_request_accepted.go
@@ -22,6 +22,9 @@ func (pk *ConnectionRequestAccepted) UnmarshalBinary(data []byte) error {
 	}
 	var offset int
 	pk.ClientAddress, offset = addr(data)
+	if len(data)-offset < 2 {
+		return io.ErrUnexpectedEOF
+	}
 	pk.SystemIndex = binary.BigEndian.Uint16(data[offset:])
 	offset += 2
 	for i := range 20 {


### PR DESCRIPTION
## What changed

- Reject split counts outside the supported `1..8192` range on both listener and dialer connections.
- Use a 256-slot split-ID ring to bound concurrent reassembly state while tolerating legitimate interleaving.
- Ignore duplicate split fragments and distinguish missing fragments from received empty fragments.
- Return `io.ErrUnexpectedEOF` when `ConnectionRequestAccepted` ends before `SystemIndex`.

## Why

Invalid split counts could previously panic or allocate excessive memory on dialer connections. The listener-only limits also rejected valid servers using more than 512 fragments or interleaving more than 16 split packets. Duplicate fragments could overwrite retained data, and a truncated accepted-connection packet could panic during decoding.