### PR TITLE
fix: refresh repeated RakNet challenges

### DIFF
--- a/dial.go
+++ b/dial.go
@@ -426,20 +426,8 @@ func (state *connState) openConnection(ctx context.Context) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	startRequest2 := func(mtu uint16, serverSecurity bool, cookie uint32) (context.CancelFunc, <-chan struct{}) {
-		requestCtx, cancelRequest := context.WithCancel(ctx)
-		done := make(chan struct{})
-		go func() {
-			defer close(done)
-			state.request2(requestCtx, mtu, serverSecurity, cookie)
-		}()
-		return cancelRequest, done
-	}
-	cancelRequest2, request2Done := startRequest2(state.mtu, state.serverSecurity, state.cookie)
-	defer func() {
-		cancelRequest2()
-		<-request2Done
-	}()
+	request2Ctx, cancelRequest2 := context.WithCancel(ctx)
+	go state.request2(request2Ctx, state.mtu, state.serverSecurity, state.cookie)
 
 	b := make([]byte, maxMTUSize)
 	for {
@@ -468,11 +456,8 @@ func (state *connState) openConnection(ctx context.Context) error {
 			}
 			state.mtu, state.serverSecurity, state.cookie = pk.MTU, pk.ServerHasSecurity, pk.Cookie
 			cancelRequest2()
-			<-request2Done
-			if err := ctx.Err(); err != nil {
-				return err
-			}
-			cancelRequest2, request2Done = startRequest2(state.mtu, state.serverSecurity, state.cookie)
+			request2Ctx, cancelRequest2 = context.WithCancel(ctx)
+			go state.request2(request2Ctx, state.mtu, state.serverSecurity, state.cookie)
 		case message.IDOpenConnectionReply2:
 			pk := &message.OpenConnectionReply2{}
 			if err = pk.UnmarshalBinary(b[1:n]); err != nil {
@@ -486,11 +471,12 @@ func (state *connState) openConnection(ctx context.Context) error {
 
 // request2 continuously sends a message.OpenConnectionRequest2 every 500ms.
 func (state *connState) request2(ctx context.Context, mtu uint16, serverSecurity bool, cookie uint32) {
-	state.ticker.Reset(time.Second / 2)
+	ticker := time.NewTicker(time.Second / 2)
+	defer ticker.Stop()
 	for {
 		state.openConnectionRequest2(mtu, serverSecurity, cookie)
 		select {
-		case <-state.ticker.C:
+		case <-ticker.C:
 			continue
 		case <-ctx.Done():
 			return

--- a/dial.go
+++ b/dial.go
@@ -388,7 +388,7 @@ func (state *connState) discoverMTU(ctx context.Context) error {
 				// protection. For some reason they send a broken MTU size
 				// first. Sending a Request2 followed by a Request1 deals with
 				// this.
-				state.openConnectionRequest2(response.MTU)
+				state.openConnectionRequest2(response.MTU, state.serverSecurity, state.cookie)
 				continue
 			}
 			state.mtu = response.MTU
@@ -426,7 +426,12 @@ func (state *connState) openConnection(ctx context.Context) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	go state.request2(ctx, state.mtu)
+	updates := make(chan openConnectionRequest2)
+	go state.request2(ctx, openConnectionRequest2{
+		mtu:            state.mtu,
+		serverSecurity: state.serverSecurity,
+		cookie:         state.cookie,
+	}, updates)
 
 	b := make([]byte, maxMTUSize)
 	for {
@@ -444,25 +449,51 @@ func (state *connState) openConnection(ctx context.Context) error {
 		if n == 0 {
 			continue
 		}
-		if b[0] != message.IDOpenConnectionReply2 {
-			continue
+		switch b[0] {
+		case message.IDOpenConnectionReply1:
+			pk := &message.OpenConnectionReply1{}
+			if err = pk.UnmarshalBinary(b[1:n]); err != nil {
+				return fmt.Errorf("read open connection reply 1: %w", err)
+			}
+			if pk.ServerGUID == 0 || pk.MTU < 400 || pk.MTU > 1500 {
+				continue
+			}
+			state.mtu, state.serverSecurity, state.cookie = pk.MTU, pk.ServerHasSecurity, pk.Cookie
+			select {
+			case updates <- openConnectionRequest2{
+				mtu:            state.mtu,
+				serverSecurity: state.serverSecurity,
+				cookie:         state.cookie,
+			}:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		case message.IDOpenConnectionReply2:
+			pk := &message.OpenConnectionReply2{}
+			if err = pk.UnmarshalBinary(b[1:n]); err != nil {
+				return fmt.Errorf("read open connection reply 2: %w", err)
+			}
+			state.mtu = pk.MTU
+			return nil
 		}
-		pk := &message.OpenConnectionReply2{}
-		if err = pk.UnmarshalBinary(b[1:n]); err != nil {
-			return fmt.Errorf("read open connection reply 2: %w", err)
-		}
-		state.mtu = pk.MTU
-		return nil
 	}
 }
 
+type openConnectionRequest2 struct {
+	mtu            uint16
+	serverSecurity bool
+	cookie         uint32
+}
+
 // request2 continuously sends a message.OpenConnectionRequest2 every 500ms.
-func (state *connState) request2(ctx context.Context, mtu uint16) {
+func (state *connState) request2(ctx context.Context, request openConnectionRequest2, updates <-chan openConnectionRequest2) {
 	state.ticker.Reset(time.Second / 2)
 	for {
-		state.openConnectionRequest2(mtu)
+		state.openConnectionRequest2(request.mtu, request.serverSecurity, request.cookie)
 		select {
 		case <-state.ticker.C:
+			continue
+		case request = <-updates:
 			continue
 		case <-ctx.Done():
 			return
@@ -479,13 +510,13 @@ func (state *connState) openConnectionRequest1(mtu uint16) {
 
 // openConnectionRequest2 sends an open connection request 2 packet to the
 // server. If not successful, an error is returned.
-func (state *connState) openConnectionRequest2(mtu uint16) {
+func (state *connState) openConnectionRequest2(mtu uint16, serverSecurity bool, cookie uint32) {
 	data, _ := (&message.OpenConnectionRequest2{
 		ServerAddress:     resolve(state.raddr),
 		MTU:               mtu,
 		ClientGUID:        state.id,
-		ServerHasSecurity: state.serverSecurity,
-		Cookie:            state.cookie,
+		ServerHasSecurity: serverSecurity,
+		Cookie:            cookie,
 	}).MarshalBinary()
 	_, _ = state.conn.Write(data)
 }

--- a/dial.go
+++ b/dial.go
@@ -383,7 +383,7 @@ func (state *connState) discoverMTU(ctx context.Context) error {
 				return fmt.Errorf("read open connection reply 1: %w", err)
 			}
 			state.serverSecurity, state.cookie = response.ServerHasSecurity, response.Cookie
-			if response.ServerGUID == 0 || response.MTU < 400 || response.MTU > 1500 {
+			if response.ServerGUID == 0 || response.MTU < minMTUSize || response.MTU > maxMTUSize {
 				// This is an awful hack we cooked up to deal with OVH 'DDoS'
 				// protection. For some reason they send a broken MTU size
 				// first. Sending a Request2 followed by a Request1 deals with
@@ -451,7 +451,7 @@ func (state *connState) openConnection(ctx context.Context) error {
 			if err = pk.UnmarshalBinary(b[1:n]); err != nil {
 				return fmt.Errorf("read open connection reply 1: %w", err)
 			}
-			if pk.ServerGUID == 0 || pk.MTU < 400 || pk.MTU > 1500 {
+			if pk.ServerGUID == 0 || pk.MTU < minMTUSize || pk.MTU > maxMTUSize {
 				continue
 			}
 			state.mtu, state.serverSecurity, state.cookie = pk.MTU, pk.ServerHasSecurity, pk.Cookie

--- a/dial.go
+++ b/dial.go
@@ -426,12 +426,20 @@ func (state *connState) openConnection(ctx context.Context) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	updates := make(chan openConnectionRequest2)
-	go state.request2(ctx, openConnectionRequest2{
-		mtu:            state.mtu,
-		serverSecurity: state.serverSecurity,
-		cookie:         state.cookie,
-	}, updates)
+	startRequest2 := func(mtu uint16, serverSecurity bool, cookie uint32) (context.CancelFunc, <-chan struct{}) {
+		requestCtx, cancelRequest := context.WithCancel(ctx)
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			state.request2(requestCtx, mtu, serverSecurity, cookie)
+		}()
+		return cancelRequest, done
+	}
+	cancelRequest2, request2Done := startRequest2(state.mtu, state.serverSecurity, state.cookie)
+	defer func() {
+		cancelRequest2()
+		<-request2Done
+	}()
 
 	b := make([]byte, maxMTUSize)
 	for {
@@ -459,15 +467,12 @@ func (state *connState) openConnection(ctx context.Context) error {
 				continue
 			}
 			state.mtu, state.serverSecurity, state.cookie = pk.MTU, pk.ServerHasSecurity, pk.Cookie
-			select {
-			case updates <- openConnectionRequest2{
-				mtu:            state.mtu,
-				serverSecurity: state.serverSecurity,
-				cookie:         state.cookie,
-			}:
-			case <-ctx.Done():
-				return ctx.Err()
+			cancelRequest2()
+			<-request2Done
+			if err := ctx.Err(); err != nil {
+				return err
 			}
+			cancelRequest2, request2Done = startRequest2(state.mtu, state.serverSecurity, state.cookie)
 		case message.IDOpenConnectionReply2:
 			pk := &message.OpenConnectionReply2{}
 			if err = pk.UnmarshalBinary(b[1:n]); err != nil {
@@ -479,21 +484,13 @@ func (state *connState) openConnection(ctx context.Context) error {
 	}
 }
 
-type openConnectionRequest2 struct {
-	mtu            uint16
-	serverSecurity bool
-	cookie         uint32
-}
-
 // request2 continuously sends a message.OpenConnectionRequest2 every 500ms.
-func (state *connState) request2(ctx context.Context, request openConnectionRequest2, updates <-chan openConnectionRequest2) {
+func (state *connState) request2(ctx context.Context, mtu uint16, serverSecurity bool, cookie uint32) {
 	state.ticker.Reset(time.Second / 2)
 	for {
-		state.openConnectionRequest2(request.mtu, request.serverSecurity, request.cookie)
+		state.openConnectionRequest2(mtu, serverSecurity, cookie)
 		select {
 		case <-state.ticker.C:
-			continue
-		case request = <-updates:
 			continue
 		case <-ctx.Done():
 			return


### PR DESCRIPTION
## Summary

- handle `OpenConnectionReply1` during the Request2 phase
- refresh the negotiated MTU, security flag, and cookie
- resend Request2 immediately through the existing sender

## Problem

Some protected RakNet endpoints issue another Reply1 after receiving the
first Request2. That reply carries a replacement security cookie. The dialer
currently ignores it and keeps retrying Request2 with the stale cookie until
the connection deadline expires.

Observed packet flow before the fix:

```
Reply1(cookie A) -> Request2(cookie A) -> Reply1(cookie B)
-> Request2(cookie A) ... timeout
```

After refreshing the Request2 state:

```
Reply1(cookie A) -> Request2(cookie A) -> Reply1(cookie B)
-> Request2(cookie B) -> Reply2
```

## Scope

This only fixes the initial open-connection handshake. Reconnect teardown and
expired-reader behavior are intentionally excluded.

## Validation

- live UDP packet trace against a protected Bedrock endpoint
- `gofmt -w dial.go`
- `git diff --check`
- no automated tests added
