### PR TITLE
Add send-path PMTUD for low-MTU clients

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -59,10 +59,14 @@ type Conn struct {
 	seq, orderIndex, messageIndex uint24
 	splitID                       uint32
 
-	// mtu is the MTU size of the connection. Packets longer than this size
-	// must be split into fragments for them to arrive at the client without
-	// losing bytes.
+	// mtu is the handshake-negotiated MTU. It is the maximum we will ever
+	// send; vanilla clients lock to this value for the session.
 	mtu uint16
+	// sendMTU is the current send cap. It starts at InitialSendMTU (if set)
+	// and is raised when a probe of that size is ACKed.
+	sendMTU   atomic.Uint32
+	discover  sendMTUDiscovery
+	onSendMTU func(addr net.Addr, sendMTU uint16)
 
 	// splits is a map of slices indexed by split IDs. The length of each of the
 	// slices is equal to the split count, and packets are positioned in that
@@ -96,8 +100,12 @@ type Conn struct {
 
 // newConn constructs a new connection specifically dedicated to the address
 // passed.
-func newConn(conn net.PacketConn, raddr net.Addr, mtu uint16, h connectionHandler) *Conn {
+func newConn(conn net.PacketConn, raddr net.Addr, mtu, initialSend uint16, h connectionHandler) *Conn {
 	mtu = clampMTU(mtu, minMTUSize)
+	send := mtu
+	if initialSend != 0 {
+		send = min(clampMTU(initialSend, minMTUSize), mtu)
+	}
 	c := &Conn{
 		raddr:          raddr,
 		conn:           conn,
@@ -114,6 +122,10 @@ func newConn(conn net.PacketConn, raddr net.Addr, mtu uint16, h connectionHandle
 		ackBuf:         bytes.NewBuffer(make([]byte, 0, 128)),
 		nackBuf:        bytes.NewBuffer(make([]byte, 0, 64)),
 	}
+	c.sendMTU.Store(uint32(send))
+	if initialSend == 0 || send >= mtu {
+		c.discover.done = true
+	}
 	c.ctx, c.cancelFunc = context.WithCancel(context.Background())
 	t := time.Now()
 	c.lastActivity.Store(&t)
@@ -129,10 +141,16 @@ func clampMTU(mtu, minMTU uint16) uint16 {
 	return max(mtu, minMTU)
 }
 
-// effectiveMTU returns the mtu size without the space allocated for IP and
-// UDP headers (28 bytes).
+// effectiveMTU returns the current send MTU without the space allocated for
+// IP and UDP headers (28 bytes).
 func (conn *Conn) effectiveMTU() uint16 {
-	return conn.mtu - 28
+	return uint16(conn.sendMTU.Load()) - 28
+}
+
+// MTU returns the current send MTU. After handshake this may be below the
+// negotiated maximum until send-path probes are ACKed.
+func (conn *Conn) MTU() uint16 {
+	return uint16(conn.sendMTU.Load())
 }
 
 // startTicking makes the connection start ticking, sending ACKs and pings to
@@ -154,6 +172,9 @@ func (conn *Conn) startTicking() {
 			if i%3 == 0 {
 				conn.checkResend(t)
 			}
+			conn.mu.Lock()
+			conn.maybeProbeSendMTU(t)
+			conn.mu.Unlock()
 			if unix := conn.closing.Load(); unix != 0 {
 				before := acksLeft
 				conn.mu.Lock()
@@ -216,6 +237,9 @@ func (conn *Conn) checkResend(now time.Time) {
 	conn.rtt.Store(int64(rtt))
 
 	for seq, t := range conn.retransmission.unacknowledged {
+		if conn.discover.isPending(seq) {
+			continue
+		}
 		// These packets have not been acknowledged for too long: We resend them
 		// by ourselves, even though no NACK has been issued yet.
 		if now.Sub(t.timestamp) > delay {
@@ -290,7 +314,7 @@ func (conn *Conn) write(b []byte, rel reliability) (n int, err error) {
 			pk.splitIndex = uint32(splitIndex)
 			pk.splitID = splitID
 		}
-		if err = conn.sendDatagram(pk); err != nil {
+		if _, err = conn.sendDatagram(pk); err != nil {
 			return 0, err
 		}
 		n += len(content)
@@ -619,6 +643,7 @@ func (conn *Conn) handleACK(b []byte) error {
 	for _, sequenceNumber := range ack.packets {
 		// Take out all stored packets from the recovery queue.
 		if p, ok := conn.retransmission.acknowledge(sequenceNumber); ok {
+			conn.onProbeAck(sequenceNumber)
 			// Clear the packet and return it to the pool so that it may be
 			// re-used.
 			p.content = p.content[:0]
@@ -645,11 +670,14 @@ func (conn *Conn) handleNACK(b []byte) error {
 // numbers passed.
 func (conn *Conn) resend(sequenceNumbers []uint24) (err error) {
 	for _, sequenceNumber := range sequenceNumbers {
+		if conn.discover.isPending(sequenceNumber) {
+			continue
+		}
 		pk, ok := conn.retransmission.retransmit(sequenceNumber)
 		if !ok {
 			continue
 		}
-		if err = conn.sendDatagram(pk); err != nil {
+		if _, err = conn.sendDatagram(pk); err != nil {
 			return err
 		}
 	}
@@ -658,7 +686,7 @@ func (conn *Conn) resend(sequenceNumbers []uint24) (err error) {
 
 // sendDatagram sends a datagram over the connection that includes the packet
 // passed. It is assigned a new sequence number and added to the retransmission.
-func (conn *Conn) sendDatagram(pk *packet) error {
+func (conn *Conn) sendDatagram(pk *packet) (uint24, error) {
 	conn.buf.WriteByte(bitFlagDatagram | bitFlagNeedsBAndAS)
 	seq := conn.seq.Inc()
 	writeUint24(conn.buf, seq)
@@ -672,9 +700,9 @@ func (conn *Conn) sendDatagram(pk *packet) error {
 	}
 
 	if err := conn.writeTo(conn.buf.Bytes(), conn.raddr); err != nil {
-		return fmt.Errorf("send datagram: %w", err)
+		return seq, fmt.Errorf("send datagram: %w", err)
 	}
-	return nil
+	return seq, nil
 }
 
 // writeTo calls WriteTo on the underlying UDP connection and returns an error

--- a/dial.go
+++ b/dial.go
@@ -116,6 +116,10 @@ type Dialer struct {
 	// server. Capping the MTU keeps every packet inside a single IP
 	// datagram for the entire connection.
 	MaxMTU uint16
+	// InitialSendMTU, if non-zero, is the datagram size used for sending
+	// immediately after the handshake. The connection then probes upward
+	// toward the negotiated MTU. Zero means send at the negotiated MTU.
+	InitialSendMTU uint16
 }
 
 // Ping sends a ping to an address and returns the response obtained. If
@@ -264,7 +268,7 @@ func (dialer Dialer) DialContext(ctx context.Context, address string) (*Conn, er
 // dial finishes the RakNet connection sequence and returns a Conn if
 // successful.
 func (dialer Dialer) connect(ctx context.Context, state *connState) (*Conn, error) {
-	conn := newConn(internal.ConnToPacketConn(state.conn), state.raddr, state.mtu, dialerConnectionHandler{l: dialer.ErrorLog})
+	conn := newConn(internal.ConnToPacketConn(state.conn), state.raddr, state.mtu, dialer.InitialSendMTU, dialerConnectionHandler{l: dialer.ErrorLog})
 	if err := conn.send((&message.ConnectionRequest{ClientGUID: state.id, RequestTime: timestamp()})); err != nil {
 		return nil, dialer.error("dial", fmt.Errorf("send connection request: %w", err))
 	}

--- a/handler.go
+++ b/handler.go
@@ -144,7 +144,9 @@ func (h listenerConnectionHandler) handleOpenConnectionRequest2(b []byte, addr n
 	}
 
 	go func() {
-		conn := newConn(h.l.conn, addr, mtuSize, h)
+		conn := newConn(h.l.conn, addr, mtuSize, h.l.initialSendMTU(addr), h)
+		conn.onSendMTU = h.l.conf.OnSendMTU
+		conn.notifySendMTU()
 		h.l.connections.Store(resolve(addr), conn)
 
 		t := time.NewTimer(time.Second * 10)

--- a/listener.go
+++ b/listener.go
@@ -39,6 +39,23 @@ type ListenConfig struct {
 	// MaxMTU caps the largest MTU negotiated with incoming clients. If zero,
 	// the maximum supported MTU is used.
 	MaxMTU uint16
+	// InitialSendMTU, if non-zero, is the datagram size used for sending
+	// immediately after the handshake. The connection then probes upward
+	// toward the negotiated MTU. Zero means send at the negotiated MTU
+	// (historical behaviour).
+	//
+	// Use this so low-MTU paths (WARP, T-Mobile, hotspots) can finish a
+	// 1492-byte handshake but only receive packets that fit until a probe
+	// of that size is ACKed. Vanilla clients do not raise their own send
+	// MTU after the handshake — this is send-path discovery only.
+	InitialSendMTU uint16
+	// InitialSendMTUFunc, if set, overrides InitialSendMTU per remote
+	// address when the connection is created. Return 0 to fall back to
+	// InitialSendMTU. Called on the handshake goroutine — keep it fast.
+	InitialSendMTUFunc func(addr net.Addr) uint16
+	// OnSendMTU, if set, is called when the send MTU is first set and
+	// whenever a probe raises it. Must not call back into Conn.
+	OnSendMTU func(addr net.Addr, sendMTU uint16)
 	// BlockDuration specifies how long IP addresses should be blocked if an
 	// error is encountered during the handling of packets from an address.
 	// BlockDuration defaults to 10s. If set to a negative value, IP addresses
@@ -206,6 +223,15 @@ func (listener *Listener) maxMTU() uint16 {
 	return clampMTU(listener.conf.MaxMTU, minMTUSize)
 }
 
+func (listener *Listener) initialSendMTU(addr net.Addr) uint16 {
+	if f := listener.conf.InitialSendMTUFunc; f != nil {
+		if v := f(addr); v != 0 {
+			return v
+		}
+	}
+	return listener.conf.InitialSendMTU
+}
+
 // listen continuously reads from the listener's UDP connection, until closed
 // has a value in it.
 func (listener *Listener) listen() {
@@ -316,7 +342,7 @@ func (s *security) blockFor(addr net.Addr, duration time.Duration) {
 	defer s.mu.Unlock()
 
 	ip := [16]byte(addr.(*net.UDPAddr).IP.To16())
-	
+
 	if _, ok := s.blocks[ip]; !ok {
 		s.blockCount.Add(1)
 	}
@@ -345,7 +371,7 @@ func (s *security) blocked(addr net.Addr) bool {
 		s.blockCount.Store(uint32(len(s.blocks)))
 		return false
 	}
-	
+
 	return true
 }
 

--- a/mtu.go
+++ b/mtu.go
@@ -1,0 +1,133 @@
+package raknet
+
+import (
+	"encoding/binary"
+	"time"
+
+	"github.com/sandertv/go-raknet/internal/message"
+)
+
+// sendMTUProbeSizes are tried in order after InitialSendMTU, up to the
+// handshake-negotiated MTU. 1280 is IPv6/WARP, 1400 is vanilla BDS, 1492 is max.
+var sendMTUProbeSizes = []uint16{1280, 1400, maxMTUSize}
+
+const (
+	// reliableProbeOverhead is datagram flags+seq + packet header+len + message index.
+	reliableProbeOverhead = 1 + 3 + 1 + 2 + 3
+	mtuProbeMaxAttempts   = 3
+)
+
+// sendMTUDiscovery tracks post-handshake upward probes of the send path.
+// The negotiated conn.mtu stays whatever the client agreed; we only raise
+// sendMTU after a probe datagram of that size is ACKed. Vanilla clients do
+// not raise their own send MTU — this is server/dialer send-path only.
+type sendMTUDiscovery struct {
+	done     bool
+	pending  uint24
+	size     uint16
+	sentAt   time.Time
+	attempts int
+}
+
+func (conn *Conn) maybeProbeSendMTU(now time.Time) {
+	if conn.discover.done || uint16(conn.sendMTU.Load()) >= conn.mtu {
+		conn.discover.done = true
+		return
+	}
+	select {
+	case <-conn.connected:
+	default:
+		return
+	}
+
+	if conn.discover.pending != 0 {
+		timeout := max(500*time.Millisecond, time.Duration(conn.rtt.Load())*3)
+		if now.Sub(conn.discover.sentAt) < timeout {
+			return
+		}
+		// Drop the oversized datagram so checkResend does not keep blasting
+		// it at a path that cannot take it.
+		if pk, ok := conn.retransmission.acknowledge(conn.discover.pending); ok {
+			pk.content = pk.content[:0]
+			packetPool.Put(pk)
+		}
+		conn.discover.pending = 0
+		conn.discover.attempts++
+		if conn.discover.attempts >= mtuProbeMaxAttempts {
+			conn.discover.done = true
+			return
+		}
+		conn.sendSendMTUProbe(conn.discover.size, now)
+		return
+	}
+
+	next := conn.nextSendMTUProbe()
+	if next == 0 {
+		conn.discover.done = true
+		return
+	}
+	conn.discover.attempts = 0
+	conn.sendSendMTUProbe(next, now)
+}
+
+func (conn *Conn) nextSendMTUProbe() uint16 {
+	cur := uint16(conn.sendMTU.Load())
+	for _, s := range sendMTUProbeSizes {
+		if s > cur && s <= conn.mtu {
+			return s
+		}
+	}
+	return 0
+}
+
+func (conn *Conn) sendSendMTUProbe(target uint16, now time.Time) {
+	udp := int(target - 28)
+	contentLen := udp - reliableProbeOverhead
+	if contentLen < 9 {
+		conn.discover.done = true
+		return
+	}
+	content := make([]byte, contentLen)
+	content[0] = message.IDConnectedPing
+	binary.BigEndian.PutUint64(content[1:], uint64(timestamp()))
+
+	pk := packetPool.Get().(*packet)
+	pk.reliability = reliabilityReliable
+	pk.split = false
+	pk.content = content
+	pk.messageIndex = conn.messageIndex.Inc()
+
+	seq, err := conn.sendDatagram(pk)
+	if err != nil {
+		pk.content = pk.content[:0]
+		packetPool.Put(pk)
+		return
+	}
+	conn.discover.pending = seq
+	conn.discover.size = target
+	conn.discover.sentAt = now
+}
+
+func (conn *Conn) onProbeAck(seq uint24) {
+	if conn.discover.pending == 0 || seq != conn.discover.pending {
+		return
+	}
+	if conn.discover.size > uint16(conn.sendMTU.Load()) && conn.discover.size <= conn.mtu {
+		conn.sendMTU.Store(uint32(conn.discover.size))
+		conn.notifySendMTU()
+	}
+	conn.discover.pending = 0
+	conn.discover.attempts = 0
+	conn.discover.size = 0
+}
+
+func (d *sendMTUDiscovery) isPending(seq uint24) bool {
+	return d.pending != 0 && d.pending == seq
+}
+
+func (conn *Conn) notifySendMTU() {
+	if conn.onSendMTU == nil {
+		return
+	}
+	conn.onSendMTU(conn.raddr, uint16(conn.sendMTU.Load()))
+}

--- a/mtu_test.go
+++ b/mtu_test.go
@@ -1,0 +1,218 @@
+package raknet
+
+import (
+	"net"
+	"testing"
+	"time"
+)
+
+func TestNextSendMTUProbe(t *testing.T) {
+	c := &Conn{mtu: 1492}
+	c.sendMTU.Store(1200)
+	if g := c.nextSendMTUProbe(); g != 1280 {
+		t.Fatalf("from 1200: got %d", g)
+	}
+	c.sendMTU.Store(1280)
+	if g := c.nextSendMTUProbe(); g != 1400 {
+		t.Fatalf("from 1280: got %d", g)
+	}
+	c.sendMTU.Store(1400)
+	if g := c.nextSendMTUProbe(); g != 1492 {
+		t.Fatalf("from 1400: got %d", g)
+	}
+	c.sendMTU.Store(1492)
+	if g := c.nextSendMTUProbe(); g != 0 {
+		t.Fatalf("at max: got %d", g)
+	}
+	c.sendMTU.Store(1200)
+	c.mtu = 1200
+	if g := c.nextSendMTUProbe(); g != 0 {
+		t.Fatalf("handshake-capped: got %d", g)
+	}
+}
+
+func TestOnProbeAckRaisesSendMTU(t *testing.T) {
+	c := &Conn{mtu: 1492}
+	c.sendMTU.Store(1200)
+	c.discover.pending = 7
+	c.discover.size = 1280
+	c.onProbeAck(7)
+	if c.MTU() != 1280 {
+		t.Fatalf("got %d", c.MTU())
+	}
+	c.onProbeAck(7)
+	if c.MTU() != 1280 {
+		t.Fatalf("stale ack changed mtu: %d", c.MTU())
+	}
+}
+
+func TestOnProbeAckDoesNotExceedNegotiated(t *testing.T) {
+	c := &Conn{mtu: 1400}
+	c.sendMTU.Store(1200)
+	c.discover.pending = 1
+	c.discover.size = 1492
+	c.onProbeAck(1)
+	if c.MTU() != 1200 {
+		t.Fatalf("raised past negotiated: %d", c.MTU())
+	}
+}
+
+func TestInitialSendMTUFuncHint(t *testing.T) {
+	l, err := ListenConfig{
+		InitialSendMTU: 1200,
+		InitialSendMTUFunc: func(net.Addr) uint16 {
+			return 1400
+		},
+	}.Listen("127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Close()
+
+	errc := make(chan error, 1)
+	var server *Conn
+	go func() {
+		c, err := l.Accept()
+		if err != nil {
+			errc <- err
+			return
+		}
+		server = c.(*Conn)
+		errc <- nil
+	}()
+
+	client, err := Dial(l.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	select {
+	case err := <-errc:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("accept timeout")
+	}
+	defer server.Close()
+
+	if server.MTU() < 1400 {
+		t.Fatalf("hint ignored: send MTU %d", server.MTU())
+	}
+}
+
+func TestSendPathMTUDiscoveryLocalhost(t *testing.T) {
+	l, err := ListenConfig{InitialSendMTU: 1200}.Listen("127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Close()
+
+	errc := make(chan error, 1)
+	var server *Conn
+	go func() {
+		c, err := l.Accept()
+		if err != nil {
+			errc <- err
+			return
+		}
+		server = c.(*Conn)
+		errc <- nil
+	}()
+
+	client, err := Dial(l.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	select {
+	case err := <-errc:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("accept timeout")
+	}
+	defer server.Close()
+
+	if server.MTU() != 1200 {
+		t.Fatalf("server send MTU at accept: got %d want 1200", server.MTU())
+	}
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if server.MTU() == maxMTUSize {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("server send MTU did not reach %d, stuck at %d", maxMTUSize, server.MTU())
+}
+
+type dropLargeListener struct{ max int }
+
+func (d dropLargeListener) ListenPacket(network, address string) (net.PacketConn, error) {
+	c, err := net.ListenPacket(network, address)
+	if err != nil {
+		return nil, err
+	}
+	return dropLarge{PacketConn: c, max: d.max}, nil
+}
+
+type dropLarge struct {
+	net.PacketConn
+	max int
+}
+
+func (d dropLarge) WriteTo(p []byte, addr net.Addr) (int, error) {
+	if len(p) > d.max {
+		return len(p), nil
+	}
+	return d.PacketConn.WriteTo(p, addr)
+}
+
+func TestSendPathMTUDiscoveryStopsWhenLargeDropped(t *testing.T) {
+	l, err := ListenConfig{
+		InitialSendMTU:         1200,
+		UpstreamPacketListener: dropLargeListener{max: 1200 - 28},
+	}.Listen("127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Close()
+
+	errc := make(chan error, 1)
+	var server *Conn
+	go func() {
+		c, err := l.Accept()
+		if err != nil {
+			errc <- err
+			return
+		}
+		server = c.(*Conn)
+		errc <- nil
+	}()
+
+	client, err := Dial(l.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	select {
+	case err := <-errc:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("accept timeout")
+	}
+	defer server.Close()
+
+	time.Sleep(2 * time.Second)
+	if server.MTU() != 1200 {
+		t.Fatalf("low-MTU path raised send MTU to %d", server.MTU())
+	}
+}


### PR DESCRIPTION
## Summary
Handshake still negotiates up to 1492. `InitialSendMTU` (and optional `InitialSendMTUFunc`) starts sending small and climbs 1280 → 1400 → 1492 when a probe datagram is ACKed. Failed probes are not retransmitted, so WARP/T-Mobile paths stay at a working size instead of locking every client to 1200.

Vanilla clients do not raise their own send MTU after handshake — this is send-path only. `OnSendMTU` reports raises for proxies that want to hint the next hop.

## Test plan
- [x] `go test -run 'TestNextSendMTUProbe|TestOnProbeAck|TestSendPathMTUDiscovery|TestInitialSendMTUFunc|TestListen'`
- [ ] Confirm a vanilla client on ethernet climbs to 1492
- [ ] Confirm a WARP/T-Mobile client can join and stays at a working send MTU

Made with [Cursor](https://cursor.com)