### PR TITLE
Add ACK-driven congestion control to the send path

### DIFF
--- a/binary.go
+++ b/binary.go
@@ -12,7 +12,7 @@ type uint24 uint32
 // Inc increments a uint24 and returns the old value.
 func (u *uint24) Inc() (old uint24) {
 	ret := *u
-	*u += 1
+	*u = (*u + 1) & 0xffffff
 	return ret
 }
 

--- a/congestion.go
+++ b/congestion.go
@@ -1,0 +1,93 @@
+package raknet
+
+import "math"
+
+// congestionWindow limits reliable bytes in flight. Counts use encapsulated
+// packet sizes and exclude the 4-byte datagram header. ACKs grow the window
+// through slow start and then congestion avoidance. A NAK begins recovery by
+// lowering the threshold; a timeout also resets the window to one MTU.
+type congestionWindow struct {
+	mtu        uint32
+	window     float64
+	threshold  float64
+	inFlight   uint32
+	nextBlock  uint24
+	backedOff  bool
+	continuous bool
+}
+
+func newCongestionWindow(mtu uint16) congestionWindow {
+	return congestionWindow{mtu: uint32(mtu), window: float64(mtu)}
+}
+
+func (c *congestionWindow) transmissionBandwidth() uint32 {
+	if float64(c.inFlight) >= c.window {
+		return 0
+	}
+	// Clamped because converting a float64 above math.MaxUint32 is undefined.
+	return uint32(min(c.window-float64(c.inFlight), math.MaxUint32))
+}
+
+// slowStart reports whether the window is still growing by a full MTU per ACK.
+func (c *congestionWindow) slowStart() bool {
+	return c.window <= c.threshold || c.threshold == 0
+}
+
+// sent and acknowledged maintain the invariant that inFlight equals the sum of
+// the inFlightBytes of every reliable record still waiting for an ACK.
+func (c *congestionWindow) sent(bytes uint32) {
+	c.inFlight += bytes
+}
+
+func (c *congestionWindow) acknowledged(bytes uint32) {
+	if bytes >= c.inFlight {
+		c.inFlight = 0
+		return
+	}
+	c.inFlight -= bytes
+}
+
+func (c *congestionWindow) ack(sequence, nextSequence uint24) {
+	if !c.continuous {
+		return
+	}
+
+	newBlock := sequenceGreaterThan(sequence, c.nextBlock)
+	if newBlock {
+		c.backedOff = false
+		c.nextBlock = nextSequence
+	}
+	if c.slowStart() {
+		c.window += float64(c.mtu)
+		if c.threshold == 0 || c.window <= c.threshold {
+			return
+		}
+		c.window = c.threshold + float64(c.mtu*c.mtu)/c.window
+		return
+	}
+	// Congestion blocks scope recovery state; continuous ACKs use Reno additive increase.
+	c.window += float64(c.mtu*c.mtu) / c.window
+}
+
+func (c *congestionWindow) nak(nextSequence uint24) {
+	if c.continuous && !c.backedOff {
+		c.threshold = c.window / 2
+		c.nextBlock = nextSequence
+		c.backedOff = true
+	}
+}
+
+func (c *congestionWindow) resend(nextSequence uint24) {
+	if !c.continuous || c.backedOff || c.window <= float64(c.mtu*2) {
+		return
+	}
+	c.threshold = max(c.window/2, float64(c.mtu))
+	c.window = float64(c.mtu)
+	c.nextBlock = nextSequence
+	c.backedOff = true
+}
+
+func sequenceGreaterThan(a, b uint24) bool {
+	const half = uint24(0x7fffff)
+	return a != b && (b-a)&0xffffff > half
+}

--- a/congestion.go
+++ b/congestion.go
@@ -7,12 +7,18 @@ import "math"
 // through slow start and then congestion avoidance. A NAK begins recovery by
 // lowering the threshold; a timeout also resets the window to one MTU.
 type congestionWindow struct {
-	mtu        uint32
-	window     float64
-	threshold  float64
-	inFlight   uint32
-	nextBlock  uint24
-	backedOff  bool
+	mtu       uint32
+	window    float64
+	threshold float64
+	inFlight  uint32
+	// nextBlock is the sequence number that starts the next congestion block: a
+	// group of datagrams sent back to back, over which recovery happens at most
+	// once so a burst of losses is treated as one event.
+	nextBlock uint24
+	// backedOff is set once the window has been reduced for the current block.
+	backedOff bool
+	// continuous reports whether more datagrams were waiting last tick. The
+	// window only grows while the sender is actually pushing data.
 	continuous bool
 }
 
@@ -20,6 +26,8 @@ func newCongestionWindow(mtu uint16) congestionWindow {
 	return congestionWindow{mtu: uint32(mtu), window: float64(mtu)}
 }
 
+// transmissionBandwidth returns how many new reliable bytes may be sent now,
+// that is the room left in the window.
 func (c *congestionWindow) transmissionBandwidth() uint32 {
 	if float64(c.inFlight) >= c.window {
 		return 0
@@ -47,6 +55,10 @@ func (c *congestionWindow) acknowledged(bytes uint32) {
 	c.inFlight -= bytes
 }
 
+// ack grows the window for one acknowledged datagram: by a full MTU per ACK
+// during slow start, then by the Reno additive increase once past the
+// threshold. nextSequence is the next sequence number the sender will use, used
+// to scope recovery to one congestion block.
 func (c *congestionWindow) ack(sequence, nextSequence uint24) {
 	if !c.continuous {
 		return
@@ -69,6 +81,8 @@ func (c *congestionWindow) ack(sequence, nextSequence uint24) {
 	c.window += float64(c.mtu*c.mtu) / c.window
 }
 
+// nak reacts to a NAK: halve the threshold so the window stops growing, but
+// leave the window itself alone. At most once per congestion block.
 func (c *congestionWindow) nak(nextSequence uint24) {
 	if c.continuous && !c.backedOff {
 		c.threshold = c.window / 2
@@ -77,6 +91,9 @@ func (c *congestionWindow) nak(nextSequence uint24) {
 	}
 }
 
+// resend reacts to a retransmission timeout, the harder signal: halve the
+// threshold and drop the window back to one MTU. At most once per block, and
+// only once the window is large enough to be worth cutting.
 func (c *congestionWindow) resend(nextSequence uint24) {
 	if !c.continuous || c.backedOff || c.window <= float64(c.mtu*2) {
 		return
@@ -87,6 +104,8 @@ func (c *congestionWindow) resend(nextSequence uint24) {
 	c.backedOff = true
 }
 
+// sequenceGreaterThan reports whether a is ahead of b in 24-bit sequence space,
+// treating the nearer half of the ring as "ahead" so wraparound compares right.
 func sequenceGreaterThan(a, b uint24) bool {
 	const half = uint24(0x7fffff)
 	return a != b && (b-a)&0xffffff > half

--- a/congestion.go
+++ b/congestion.go
@@ -7,27 +7,20 @@ import "math"
 // through slow start and then congestion avoidance. A NAK begins recovery by
 // lowering the threshold; a timeout also resets the window to one MTU.
 type congestionWindow struct {
-	mtu       uint32
-	window    float64
-	threshold float64
-	inFlight  uint32
-	// nextBlock is the sequence number that starts the next congestion block: a
-	// group of datagrams sent back to back, over which recovery happens at most
-	// once so a burst of losses is treated as one event.
-	nextBlock uint24
-	// backedOff is set once the window has been reduced for the current block.
-	backedOff bool
-	// continuous reports whether more datagrams were waiting last tick. The
-	// window only grows while the sender is actually pushing data.
-	continuous bool
+	mtu        uint32
+	window     float64
+	threshold  float64
+	inFlight   uint32
+	nextBlock  uint24 // sequence number that starts the next congestion block
+	backedOff  bool   // window already cut for the current block
+	continuous bool   // data still queued last tick; the window only grows then
 }
 
 func newCongestionWindow(mtu uint16) congestionWindow {
 	return congestionWindow{mtu: uint32(mtu), window: float64(mtu)}
 }
 
-// transmissionBandwidth returns how many new reliable bytes may be sent now,
-// that is the room left in the window.
+// transmissionBandwidth returns the unused room in the window, in bytes.
 func (c *congestionWindow) transmissionBandwidth() uint32 {
 	if float64(c.inFlight) >= c.window {
 		return 0
@@ -55,10 +48,8 @@ func (c *congestionWindow) acknowledged(bytes uint32) {
 	c.inFlight -= bytes
 }
 
-// ack grows the window for one acknowledged datagram: by a full MTU per ACK
-// during slow start, then by the Reno additive increase once past the
-// threshold. nextSequence is the next sequence number the sender will use, used
-// to scope recovery to one congestion block.
+// ack grows the window for an acknowledged datagram: a full MTU per ACK during
+// slow start, then Reno additive increase.
 func (c *congestionWindow) ack(sequence, nextSequence uint24) {
 	if !c.continuous {
 		return
@@ -81,8 +72,8 @@ func (c *congestionWindow) ack(sequence, nextSequence uint24) {
 	c.window += float64(c.mtu*c.mtu) / c.window
 }
 
-// nak reacts to a NAK: halve the threshold so the window stops growing, but
-// leave the window itself alone. At most once per congestion block.
+// nak halves the threshold on a NAK so the window stops growing, without cutting
+// it. At most once per congestion block.
 func (c *congestionWindow) nak(nextSequence uint24) {
 	if c.continuous && !c.backedOff {
 		c.threshold = c.window / 2
@@ -91,9 +82,8 @@ func (c *congestionWindow) nak(nextSequence uint24) {
 	}
 }
 
-// resend reacts to a retransmission timeout, the harder signal: halve the
-// threshold and drop the window back to one MTU. At most once per block, and
-// only once the window is large enough to be worth cutting.
+// resend handles a retransmission timeout: halve the threshold and cut the
+// window to one MTU. At most once per block.
 func (c *congestionWindow) resend(nextSequence uint24) {
 	if !c.continuous || c.backedOff || c.window <= float64(c.mtu*2) {
 		return
@@ -104,8 +94,7 @@ func (c *congestionWindow) resend(nextSequence uint24) {
 	c.backedOff = true
 }
 
-// sequenceGreaterThan reports whether a is ahead of b in 24-bit sequence space,
-// treating the nearer half of the ring as "ahead" so wraparound compares right.
+// sequenceGreaterThan reports whether a is ahead of b in wrapping 24-bit space.
 func sequenceGreaterThan(a, b uint24) bool {
 	const half = uint24(0x7fffff)
 	return a != b && (b-a)&0xffffff > half

--- a/conn.go
+++ b/conn.go
@@ -44,9 +44,8 @@ const (
 	resendBufferSize = 512
 )
 
-// queuedDatagram is one datagram waiting to be sent: the packet, its size on
-// the wire (for the send-queue byte cap) and the bytes it counts against the
-// congestion window.
+// queuedDatagram is a datagram waiting to be sent, with its wire size and the
+// bytes it counts in flight.
 type queuedDatagram struct {
 	pk            *packet
 	wireSize      uint32
@@ -133,15 +132,9 @@ type Conn struct {
 	// sendQueueFreed is closed and replaced when the send queue frees space, so
 	// that every writer waiting on it wakes to re-check its own requirement.
 	sendQueueFreed chan struct{}
-	// sendBudget is the bytes still sendable this tick, refreshed from the
-	// congestion window at the start of each update.
-	sendBudget uint32
-	// continuousSend records whether data was still queued at the last update;
-	// the window only grows while data is actually flowing. wireContinuous is
-	// the same idea per datagram: the flag set on the wire, true for every
-	// datagram after the first in a tick.
-	continuousSend bool
-	wireContinuous bool
+	sendBudget     uint32 // bytes still sendable this tick, refreshed each update
+	continuousSend bool   // data still queued last update; the window only grows then
+	wireContinuous bool   // per-datagram continuous-send flag on the wire
 	// sendSignal wakes the connection's own goroutine, which owns every send.
 	// Receiving goroutines only mutate state and signal, so a window drain
 	// never blocks the shared read loop of a Listener.
@@ -570,10 +563,8 @@ func (conn *Conn) sendUnreliable(pk encoding.BinaryMarshaler) error {
 	return conn.writeControl(b, reliabilityUnreliable)
 }
 
-// writeControl queues an internally generated packet (a ping, a disconnect)
-// onto the control queue, which drains ahead of application data. It fails
-// instead of blocking when the queue is full, so a control send never waits on
-// backpressure.
+// writeControl queues an internal packet (ping, disconnect) ahead of application
+// data. It fails rather than blocks when the queue is full.
 func (conn *Conn) writeControl(b []byte, rel reliability) error {
 	required := conn.queuedSize(b, rel)
 	conn.mu.Lock()
@@ -900,9 +891,8 @@ func (conn *Conn) sendable(datagram queuedDatagram) bool {
 	return len(conn.retransmission.unacknowledged) < resendBufferSize
 }
 
-// drainSendQueue sends as many queued datagrams as the congestion window and
-// the resend buffer allow, control queue first. Only the connection's own send
-// goroutine calls it.
+// drainSendQueue sends what the window and resend buffer allow, control queue
+// first. Only the send goroutine calls it.
 func (conn *Conn) drainSendQueue() error {
 	// Wake blocked writers once for the whole drain rather than per datagram:
 	// they re-check the budget anyway, and each signal costs a channel.
@@ -943,8 +933,7 @@ func (conn *Conn) drainSendQueue() error {
 	return nil
 }
 
-// consumeSendBudget subtracts a sent datagram's bytes from this tick's budget,
-// stopping at zero.
+// consumeSendBudget subtracts sent bytes from this tick's budget, floored at zero.
 func (conn *Conn) consumeSendBudget(size uint32) {
 	if size >= conn.sendBudget {
 		conn.sendBudget = 0
@@ -970,11 +959,8 @@ func (conn *Conn) signalSend() {
 	}
 }
 
-// sendDatagram assigns the next sequence number to pk and writes it to the
-// socket. A reliable packet is recorded for retransmission; its size is counted
-// in flight unless retransmit is set, meaning the bytes were already counted on
-// the first send. On a write error the packet is dropped and its accounting
-// undone.
+// sendDatagram numbers pk and writes it, tracking a reliable packet for resend
+// and counting it in flight unless retransmit says it already was.
 func (conn *Conn) sendDatagram(pk *packet, size uint32, retransmit bool) error {
 	header := byte(bitFlagDatagram)
 	if conn.congestion.slowStart() {

--- a/conn.go
+++ b/conn.go
@@ -604,11 +604,9 @@ func (conn *Conn) receiveDatagram(b []byte) error {
 		return fmt.Errorf("read datagram: %w", io.ErrUnexpectedEOF)
 	}
 	seq := loadUint24(b)
-	if !conn.win.add(seq) {
-		// Datagram was already received, this might happen if a packet took a
-		// long time to arrive, and we already sent a NACK for it. This is
-		// expected to happen sometimes under normal circumstances, so no reason
-		// to return an error.
+	ok, skipped := conn.win.add(seq)
+	if !ok {
+		// A duplicate of a datagram still in the window. Not an error.
 		return nil
 	}
 	conn.ackMu.Lock()
@@ -626,16 +624,14 @@ func (conn *Conn) receiveDatagram(b []byte) error {
 	conn.ackMu.Unlock()
 	conn.signalSend()
 
-	if conn.win.shift() == 0 {
-		// Datagram window couldn't be shifted up, so we're still missing
-		// packets.
-		rtt := time.Duration(conn.rtt.Load())
-		if missing := conn.win.missing(rtt + rtt/2); len(missing) > 0 {
-			if err := conn.sendNACK(missing); err != nil {
-				return fmt.Errorf("receive datagram: send NACK: %w", err)
-			}
+	if len(skipped) > 0 {
+		// NACK the gap immediately, as the client does: a delayed report loses the
+		// race against the sender's RTO, which cuts the window for a recoverable loss.
+		if err := conn.sendNACK(skipped); err != nil {
+			return fmt.Errorf("receive datagram: send NACK: %w", err)
 		}
 	}
+	conn.win.shift()
 	if conn.win.size() > maxWindowSize && conn.handler.limitsEnabled() {
 		return fmt.Errorf("receive datagram: queue window size is too big (%v-%v)", conn.win.lowest, conn.win.highest)
 	}

--- a/conn.go
+++ b/conn.go
@@ -44,6 +44,9 @@ const (
 	resendBufferSize = 512
 )
 
+// queuedDatagram is one datagram waiting to be sent: the packet, its size on
+// the wire (for the send-queue byte cap) and the bytes it counts against the
+// congestion window.
 type queuedDatagram struct {
 	pk            *packet
 	wireSize      uint32
@@ -130,7 +133,13 @@ type Conn struct {
 	// sendQueueFreed is closed and replaced when the send queue frees space, so
 	// that every writer waiting on it wakes to re-check its own requirement.
 	sendQueueFreed chan struct{}
-	sendBudget     uint32
+	// sendBudget is the bytes still sendable this tick, refreshed from the
+	// congestion window at the start of each update.
+	sendBudget uint32
+	// continuousSend records whether data was still queued at the last update;
+	// the window only grows while data is actually flowing. wireContinuous is
+	// the same idea per datagram: the flag set on the wire, true for every
+	// datagram after the first in a tick.
 	continuousSend bool
 	wireContinuous bool
 	// sendSignal wakes the connection's own goroutine, which owns every send.
@@ -561,6 +570,10 @@ func (conn *Conn) sendUnreliable(pk encoding.BinaryMarshaler) error {
 	return conn.writeControl(b, reliabilityUnreliable)
 }
 
+// writeControl queues an internally generated packet (a ping, a disconnect)
+// onto the control queue, which drains ahead of application data. It fails
+// instead of blocking when the queue is full, so a control send never waits on
+// backpressure.
 func (conn *Conn) writeControl(b []byte, rel reliability) error {
 	required := conn.queuedSize(b, rel)
 	conn.mu.Lock()
@@ -887,6 +900,9 @@ func (conn *Conn) sendable(datagram queuedDatagram) bool {
 	return len(conn.retransmission.unacknowledged) < resendBufferSize
 }
 
+// drainSendQueue sends as many queued datagrams as the congestion window and
+// the resend buffer allow, control queue first. Only the connection's own send
+// goroutine calls it.
 func (conn *Conn) drainSendQueue() error {
 	// Wake blocked writers once for the whole drain rather than per datagram:
 	// they re-check the budget anyway, and each signal costs a channel.
@@ -927,6 +943,8 @@ func (conn *Conn) drainSendQueue() error {
 	return nil
 }
 
+// consumeSendBudget subtracts a sent datagram's bytes from this tick's budget,
+// stopping at zero.
 func (conn *Conn) consumeSendBudget(size uint32) {
 	if size >= conn.sendBudget {
 		conn.sendBudget = 0
@@ -952,6 +970,11 @@ func (conn *Conn) signalSend() {
 	}
 }
 
+// sendDatagram assigns the next sequence number to pk and writes it to the
+// socket. A reliable packet is recorded for retransmission; its size is counted
+// in flight unless retransmit is set, meaning the bytes were already counted on
+// the first send. On a write error the packet is dropped and its accounting
+// undone.
 func (conn *Conn) sendDatagram(pk *packet, size uint32, retransmit bool) error {
 	header := byte(bitFlagDatagram)
 	if conn.congestion.slowStart() {

--- a/conn.go
+++ b/conn.go
@@ -26,7 +26,29 @@ const (
 	minMTUSize    = 400
 	maxMTUSize    = 1492
 	maxWindowSize = 2048
+
+	// Bound queued application data so a stalled path cannot grow memory forever.
+	// Write waits at the limit; the reserve lets control traffic continue.
+	maxSendQueueBytes = 16 << 20
+	sendQueueReserve  = 64 << 10
+
+	// ackDelay is how long datagram acknowledgements are batched before being
+	// sent. It matches the SYN interval the client holds its own ACKs for, and
+	// bounds how far the peer's round trip estimate can be inflated by us.
+	ackDelay = time.Millisecond * 10
+
+	// resendBufferSize caps reliable datagrams awaiting acknowledgement. The
+	// client indexes a fixed 512 slot resend buffer and refuses to send new
+	// reliable data while the slot for the next message number is taken, which
+	// bounds a burst even when the congestion window is far larger.
+	resendBufferSize = 512
 )
+
+type queuedDatagram struct {
+	pk            *packet
+	wireSize      uint32
+	inFlightBytes uint32
+}
 
 // Conn represents a connection to a specific client. It is not a real
 // connection, as UDP is connectionless, but rather a connection emulated using
@@ -79,6 +101,15 @@ type Conn struct {
 	// received over the last second. When ticked, all of these packets are sent
 	// in an ACK and the slice is cleared.
 	ackSlice []uint24
+	// oldestUnsentAck is when the first sequence number still in ackSlice was
+	// received. ACKs are held back until ackDelay has passed since then.
+	oldestUnsentAck time.Time
+	// ackedAny records whether any ACK has been received. Until one has, ACKs
+	// are flushed without delay, as the peer's retransmission timer is unknown.
+	ackedAny atomic.Bool
+	// ackTimer wakes the send loop once a batch has been held for ackDelay, so
+	// a batch that no further traffic follows is not left until the next tick.
+	ackTimer *time.Timer
 
 	// packetQueue is an ordered queue containing packets indexed by their order
 	// index.
@@ -90,6 +121,22 @@ type Conn struct {
 	// retransmission is a queue filled with packets that were sent with a given
 	// datagram sequence number.
 	retransmission *resendMap
+
+	congestion congestionWindow
+	// controlQueue is drained before application data.
+	controlQueue   []queuedDatagram
+	sendQueue      []queuedDatagram
+	sendQueueBytes uint32
+	// sendQueueFreed is closed and replaced when the send queue frees space, so
+	// that every writer waiting on it wakes to re-check its own requirement.
+	sendQueueFreed chan struct{}
+	sendBudget     uint32
+	continuousSend bool
+	wireContinuous bool
+	// sendSignal wakes the connection's own goroutine, which owns every send.
+	// Receiving goroutines only mutate state and signal, so a window drain
+	// never blocks the shared read loop of a Listener.
+	sendSignal chan struct{}
 
 	lastActivity atomic.Pointer[time.Time]
 }
@@ -110,6 +157,10 @@ func newConn(conn net.PacketConn, raddr net.Addr, mtu uint16, h connectionHandle
 		win:            newDatagramWindow(),
 		packetQueue:    newPacketQueue(),
 		retransmission: newRecoveryQueue(),
+		congestion:     newCongestionWindow(mtu - 28),
+		sendQueueFreed: make(chan struct{}),
+		sendSignal:     make(chan struct{}, 1),
+		sendBudget:     uint32(mtu - 28),
 		buf:            bytes.NewBuffer(make([]byte, 0, mtu-28)), // - headers.
 		ackBuf:         bytes.NewBuffer(make([]byte, 0, 128)),
 		nackBuf:        bytes.NewBuffer(make([]byte, 0, 64)),
@@ -148,12 +199,16 @@ func (conn *Conn) startTicking() {
 	defer ticker.Stop()
 	for {
 		select {
+		case <-conn.sendSignal:
+			// Protocol activity opened the window, queued data or made a
+			// retransmission due. The client runs the same update on a 10ms
+			// timer that network activity signals early.
+			conn.flushACKs()
+			conn.update(time.Now())
 		case t := <-ticker.C:
 			i++
 			conn.flushACKs()
-			if i%3 == 0 {
-				conn.checkResend(t)
-			}
+			conn.update(t)
 			if unix := conn.closing.Load(); unix != 0 {
 				before := acksLeft
 				conn.mu.Lock()
@@ -170,15 +225,16 @@ func (conn *Conn) startTicking() {
 				continue
 			}
 			if i%5 == 0 {
-				// Ping the other end periodically to prevent timeouts.
 				_ = conn.send(&message.ConnectedPing{PingTime: timestamp()})
 
 				conn.mu.Lock()
-				if t.Sub(*conn.lastActivity.Load()) > time.Second*5+conn.retransmission.rtt(t)*2 {
-					// No activity for too long: Start timeout.
+				timedOut := t.Sub(*conn.lastActivity.Load()) > time.Second*5+conn.retransmission.rtt()*2
+				conn.mu.Unlock()
+				if timedOut {
+					// Close sends a disconnect through Write, which takes conn.mu.
+					// Do not call it while holding the same non-reentrant mutex.
 					_ = conn.Close()
 				}
-				conn.mu.Unlock()
 			}
 		case <-conn.ctx.Done():
 			return
@@ -186,42 +242,75 @@ func (conn *Conn) startTicking() {
 	}
 }
 
-// flushACKs flushes all pending datagram acknowledgements.
+// flushACKs flushes pending datagram acknowledgements once they have been held
+// for ackDelay, batching the sequence numbers received in that window.
 func (conn *Conn) flushACKs() {
 	conn.ackMu.Lock()
 	defer conn.ackMu.Unlock()
 
-	if len(conn.ackSlice) > 0 {
-		// Write an ACK packet to the connection containing all datagram
-		// sequence numbers that we received since the last tick.
-		if err := conn.sendACK(conn.ackSlice...); err != nil {
-			return
-		}
-		conn.ackSlice = conn.ackSlice[:0]
+	if len(conn.ackSlice) == 0 || !conn.ackDue(time.Now()) {
+		return
 	}
+	// Write an ACK packet to the connection containing all datagram sequence
+	// numbers that we received since the last flush.
+	if err := conn.sendACK(conn.ackSlice...); err != nil {
+		return
+	}
+	conn.ackSlice = conn.ackSlice[:0]
+	conn.oldestUnsentAck = time.Time{}
 }
 
-// checkResend checks if the connection needs to resend any packets. It sends
-// an ACK for packets it has received and sends any packets that have been
-// pending for too long.
-func (conn *Conn) checkResend(now time.Time) {
+// ackDue reports whether pending ACKs have been held long enough. It must be
+// called with ackMu held.
+func (conn *Conn) ackDue(now time.Time) bool {
+	if !conn.ackedAny.Load() {
+		// The peer's retransmission timer is still unknown, so acknowledge
+		// without delay rather than risk a spurious resend.
+		return true
+	}
+	return !now.Before(conn.oldestUnsentAck.Add(ackDelay))
+}
+
+// update runs one send cycle: it recomputes the transmission budget from the
+// congestion window, retransmits records whose timer expired and drains as much
+// of the send queue as the budget allows. Only the connection's own goroutine
+// may call it.
+func (conn *Conn) update(now time.Time) {
 	conn.mu.Lock()
 	defer conn.mu.Unlock()
 
-	var (
-		resend []uint24
-		rtt    = conn.retransmission.rtt(now)
-		delay  = rtt + rtt/2
-	)
+	conn.congestion.continuous = conn.continuousSend
+	conn.wireContinuous = conn.continuousSend
+	conn.sendBudget = conn.congestion.transmissionBandwidth()
+
+	rtt := conn.retransmission.rtt()
 	conn.rtt.Store(int64(rtt))
 
-	for seq, t := range conn.retransmission.unacknowledged {
-		// These packets have not been acknowledged for too long: We resend them
-		// by ourselves, even though no NACK has been issued yet.
-		if now.Sub(t.timestamp) > delay {
+	if conn.retransmission.due(now) {
+		conn.resendExpired(now)
+	}
+	_ = conn.drainSendQueue()
+	conn.continuousSend = len(conn.controlQueue) != 0 || len(conn.sendQueue) != 0
+}
+
+// resendExpired retransmits every record whose send timer expired, oldest
+// first, and recomputes the earliest remaining timer.
+func (conn *Conn) resendExpired(now time.Time) {
+	var resend []uint24
+	deadline := time.Time{}
+	for seq, record := range conn.retransmission.unacknowledged {
+		if !now.Before(record.nextSend) {
 			resend = append(resend, seq)
+		} else if deadline.IsZero() || record.nextSend.Before(deadline) {
+			deadline = record.nextSend
 		}
 	}
+	conn.retransmission.deadline = deadline
+	slices.SortFunc(resend, func(a, b uint24) int {
+		return conn.retransmission.unacknowledged[a].nextSend.Compare(
+			conn.retransmission.unacknowledged[b].nextSend,
+		)
+	})
 	_ = conn.resend(resend)
 }
 
@@ -244,11 +333,50 @@ func (conn *Conn) writeWithReliability(b []byte, rel reliability) (n int, err er
 	case <-conn.ctx.Done():
 		return 0, conn.error(net.ErrClosed, "write")
 	default:
-		conn.mu.Lock()
-		defer conn.mu.Unlock()
-		n, err = conn.write(b, rel)
-		return n, conn.error(err, "write")
+		if len(b) == 0 {
+			return 0, nil
+		}
+		required := conn.queuedSize(b, rel)
+		if required > maxSendQueueBytes-sendQueueReserve {
+			return 0, conn.error(fmt.Errorf("packet requires %d bytes in the send queue", required), "write")
+		}
+		for {
+			conn.mu.Lock()
+			select {
+			case <-conn.ctx.Done():
+				conn.mu.Unlock()
+				return 0, conn.error(net.ErrClosed, "write")
+			default:
+			}
+			if conn.sendQueueBytes+required <= maxSendQueueBytes-sendQueueReserve {
+				n, err = conn.write(b, rel, false)
+				conn.mu.Unlock()
+				if err != nil {
+					n = 0
+				}
+				return n, conn.error(err, "write")
+			}
+			// Captured under the lock that guards the check above, so a drain
+			// between here and the wait closes this channel rather than
+			// signalling into one nobody is listening on yet.
+			freed := conn.sendQueueFreed
+			conn.mu.Unlock()
+
+			select {
+			case <-freed:
+			case <-conn.ctx.Done():
+				return 0, conn.error(net.ErrClosed, "write")
+			}
+		}
 	}
+}
+
+// queuedSize returns the wire bytes b occupies in the send queue, headers and
+// fragmentation included.
+func (conn *Conn) queuedSize(b []byte, rel reliability) uint32 {
+	count := splitCount(len(b), conn.effectiveMTU())
+	// Fragment payloads sum to len(b), and every fragment costs the same header.
+	return uint32(len(b) + count*(encapsulatedPacketSize(0, rel, count > 1)+4))
 }
 
 // write writes a buffer b over the RakNet connection. The amount of bytes
@@ -256,7 +384,7 @@ func (conn *Conn) writeWithReliability(b []byte, rel reliability) (n int, err er
 // was successful. If not, an error is returned and n is 0. Write may be called
 // simultaneously from multiple goroutines, but will write one by one. Unlike
 // Write, write will not lock.
-func (conn *Conn) write(b []byte, rel reliability) (n int, err error) {
+func (conn *Conn) write(b []byte, rel reliability, control bool) (n int, err error) {
 	fragments := split(b, conn.effectiveMTU())
 	var orderIndex uint24
 	if rel.sequencedOrOrdered() {
@@ -290,11 +418,18 @@ func (conn *Conn) write(b []byte, rel reliability) (n int, err error) {
 			pk.splitIndex = uint32(splitIndex)
 			pk.splitID = splitID
 		}
-		if err = conn.sendDatagram(pk); err != nil {
-			return 0, err
+		inFlightBytes := uint32(encapsulatedPacketSize(len(content), rel, pk.split))
+		wireSize := inFlightBytes + 4
+		datagram := queuedDatagram{pk: pk, wireSize: wireSize, inFlightBytes: inFlightBytes}
+		if control {
+			conn.controlQueue = append(conn.controlQueue, datagram)
+		} else {
+			conn.sendQueue = append(conn.sendQueue, datagram)
 		}
+		conn.sendQueueBytes += wireSize
 		n += len(content)
 	}
+	conn.signalSend()
 	return n, nil
 }
 
@@ -342,19 +477,47 @@ func (conn *Conn) Context() context.Context {
 // connection and closes the underlying UDP connection immediately.
 func (conn *Conn) closeImmediately() {
 	conn.once.Do(func() {
-		_, _ = conn.Write([]byte{message.IDDisconnectNotification})
+		conn.mu.Lock()
+		// Queue the disconnect and flush it before the handler closes a
+		// dialer's socket, since sends otherwise belong to the send loop, which
+		// is about to stop. Nothing outstanding will be acknowledged now, so
+		// release it first: that opens the resend buffer for the flush.
+		conn.releaseUnacknowledged()
+		_, _ = conn.write([]byte{message.IDDisconnectNotification}, reliabilityReliableOrdered, true)
+		conn.sendBudget = max(conn.sendBudget, uint32(conn.effectiveMTU()))
+		_ = conn.drainSendQueue()
+		conn.mu.Unlock()
+
 		conn.handler.close(conn)
 		conn.cancelFunc()
 
 		conn.mu.Lock()
 		defer conn.mu.Unlock()
-		// Make sure to return all unacknowledged packets to the packet pool.
-		for _, record := range conn.retransmission.unacknowledged {
-			record.pk.content = record.pk.content[:0]
-			packetPool.Put(record.pk)
+		// The flush re-added whatever it sent.
+		conn.releaseUnacknowledged()
+		for _, datagram := range conn.sendQueue {
+			datagram.pk.content = datagram.pk.content[:0]
+			packetPool.Put(datagram.pk)
 		}
-		clear(conn.retransmission.unacknowledged)
+		for _, datagram := range conn.controlQueue {
+			datagram.pk.content = datagram.pk.content[:0]
+			packetPool.Put(datagram.pk)
+		}
+		conn.controlQueue = nil
+		conn.sendQueue = nil
+		conn.sendQueueBytes = 0
+		conn.signalSendQueueFreed()
 	})
+}
+
+// releaseUnacknowledged returns every packet awaiting acknowledgement to the
+// pool and forgets it. Only for a connection that is closing.
+func (conn *Conn) releaseUnacknowledged() {
+	for _, record := range conn.retransmission.unacknowledged {
+		record.pk.content = record.pk.content[:0]
+		packetPool.Put(record.pk)
+	}
+	clear(conn.retransmission.unacknowledged)
 }
 
 // RemoteAddr returns the remote address of the connection, meaning the address
@@ -388,16 +551,25 @@ func (conn *Conn) Latency() time.Duration {
 // send encodes an encoding.BinaryMarshaler and writes it to the Conn.
 func (conn *Conn) send(pk encoding.BinaryMarshaler) error {
 	b, _ := pk.MarshalBinary()
-	_, err := conn.Write(b)
-	return err
+	return conn.writeControl(b, reliabilityReliableOrdered)
 }
 
 // sendUnreliable encodes an encoding.BinaryMarshaler and writes it to the Conn using
 // unreliable reliability.
 func (conn *Conn) sendUnreliable(pk encoding.BinaryMarshaler) error {
 	b, _ := pk.MarshalBinary()
-	_, err := conn.writeWithReliability(b, reliabilityUnreliable)
-	return err
+	return conn.writeControl(b, reliabilityUnreliable)
+}
+
+func (conn *Conn) writeControl(b []byte, rel reliability) error {
+	required := conn.queuedSize(b, rel)
+	conn.mu.Lock()
+	defer conn.mu.Unlock()
+	if conn.sendQueueBytes+required > maxSendQueueBytes {
+		return conn.error(errors.New("send queue is full"), "write")
+	}
+	_, err := conn.write(b, rel, true)
+	return conn.error(err, "write")
 }
 
 // packetPool is used to pool packets that encapsulate their content.
@@ -438,8 +610,17 @@ func (conn *Conn) receiveDatagram(b []byte) error {
 	conn.ackMu.Lock()
 	// Add this sequence number to the received datagrams, so that it is
 	// included in an ACK.
+	if len(conn.ackSlice) == 0 {
+		conn.oldestUnsentAck = time.Now()
+		if conn.ackTimer == nil {
+			conn.ackTimer = time.AfterFunc(ackDelay, conn.signalSend)
+		} else {
+			conn.ackTimer.Reset(ackDelay)
+		}
+	}
 	conn.ackSlice = append(conn.ackSlice, seq)
 	conn.ackMu.Unlock()
+	conn.signalSend()
 
 	if conn.win.shift() == 0 {
 		// Datagram window couldn't be shifted up, so we're still missing
@@ -616,15 +797,18 @@ func (conn *Conn) handleACK(b []byte) error {
 	if err := ack.read(b); err != nil {
 		return fmt.Errorf("read ACK: %w", err)
 	}
+	conn.ackedAny.Store(true)
+	conn.congestion.continuous = conn.continuousSend
 	for _, sequenceNumber := range ack.packets {
-		// Take out all stored packets from the recovery queue.
-		if p, ok := conn.retransmission.acknowledge(sequenceNumber); ok {
-			// Clear the packet and return it to the pool so that it may be
-			// re-used.
-			p.content = p.content[:0]
-			packetPool.Put(p)
+		if record, ok := conn.retransmission.acknowledge(sequenceNumber); ok {
+			conn.congestion.acknowledged(record.inFlightBytes)
+			conn.congestion.ack(sequenceNumber, conn.seq)
+			record.pk.content = record.pk.content[:0]
+			packetPool.Put(record.pk)
 		}
 	}
+	// The window moved, so let the send loop recompute the budget and drain.
+	conn.signalSend()
 	return nil
 }
 
@@ -638,41 +822,172 @@ func (conn *Conn) handleNACK(b []byte) error {
 	if err := nack.read(b); err != nil {
 		return fmt.Errorf("read NACK: %w", err)
 	}
-	return conn.resend(nack.packets)
-}
-
-// resend sends all datagrams currently in the recovery queue with the sequence
-// numbers passed.
-func (conn *Conn) resend(sequenceNumbers []uint24) (err error) {
-	for _, sequenceNumber := range sequenceNumbers {
-		pk, ok := conn.retransmission.retransmit(sequenceNumber)
+	conn.congestion.nak(conn.seq)
+	// Bring the send timers forward so the next update retransmits them, which
+	// is how the client turns a NAK into a resend.
+	now := time.Now()
+	for _, sequenceNumber := range nack.packets {
+		record, ok := conn.retransmission.unacknowledged[sequenceNumber]
 		if !ok {
 			continue
 		}
-		if err = conn.sendDatagram(pk); err != nil {
+		record.nextSend = now
+		conn.retransmission.unacknowledged[sequenceNumber] = record
+		conn.retransmission.lowerDeadline(now)
+	}
+	conn.signalSend()
+	return nil
+}
+
+// resend sends all datagrams currently in the recovery queue with the sequence
+// numbers passed. A NAK reaches this through the same path as an expired timer,
+// as it does on the client: the NAK already marked the congestion block as
+// backed off, so congestionWindow.resend leaves the window alone for it.
+func (conn *Conn) resend(sequenceNumbers []uint24) (err error) {
+	// Retransmitted bytes already count as in flight. This budget caps one pass at
+	// the outstanding total and protects against accounting drift.
+	budget := conn.congestion.inFlight
+	var sent uint32
+	for _, sequenceNumber := range sequenceNumbers {
+		pending, ok := conn.retransmission.unacknowledged[sequenceNumber]
+		if !ok {
+			continue
+		}
+		if pending.inFlightBytes > budget || sent > budget-pending.inFlightBytes {
+			// Out of budget for this pass. Keep the remainder due so that the
+			// next update retries them.
+			conn.retransmission.lowerDeadline(pending.nextSend)
+			break
+		}
+		record, ok := conn.retransmission.retransmit(sequenceNumber)
+		if !ok {
+			continue
+		}
+		conn.congestion.resend(conn.seq)
+		if err = conn.sendDatagram(record.pk, record.inFlightBytes, true); err != nil {
+			return err
+		}
+		sent += record.inFlightBytes
+	}
+	if sent >= conn.sendBudget {
+		conn.sendBudget = 0
+	}
+	return nil
+}
+
+// sendable reports whether the next queued datagram fits in both the congestion
+// window and the resend buffer.
+func (conn *Conn) sendable(datagram queuedDatagram) bool {
+	if conn.sendBudget == 0 {
+		return false
+	}
+	if !datagram.pk.reliability.reliable() {
+		return true
+	}
+	return len(conn.retransmission.unacknowledged) < resendBufferSize
+}
+
+func (conn *Conn) drainSendQueue() error {
+	// Wake blocked writers once for the whole drain rather than per datagram:
+	// they re-check the budget anyway, and each signal costs a channel.
+	freed := false
+	defer func() {
+		if freed {
+			conn.signalSendQueueFreed()
+		}
+	}()
+	for len(conn.controlQueue) != 0 {
+		if !conn.sendable(conn.controlQueue[0]) {
+			return nil
+		}
+		datagram := conn.controlQueue[0]
+		conn.controlQueue[0] = queuedDatagram{}
+		conn.controlQueue = conn.controlQueue[1:]
+		conn.sendQueueBytes -= datagram.wireSize
+		freed = true
+		conn.consumeSendBudget(datagram.inFlightBytes)
+		if err := conn.sendDatagram(datagram.pk, datagram.inFlightBytes, false); err != nil {
+			return err
+		}
+	}
+	for len(conn.sendQueue) != 0 {
+		if !conn.sendable(conn.sendQueue[0]) {
+			return nil
+		}
+		datagram := conn.sendQueue[0]
+		conn.sendQueue[0] = queuedDatagram{}
+		conn.sendQueue = conn.sendQueue[1:]
+		conn.sendQueueBytes -= datagram.wireSize
+		freed = true
+		conn.consumeSendBudget(datagram.inFlightBytes)
+		if err := conn.sendDatagram(datagram.pk, datagram.inFlightBytes, false); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-// sendDatagram sends a datagram over the connection that includes the packet
-// passed. It is assigned a new sequence number and added to the retransmission.
-func (conn *Conn) sendDatagram(pk *packet) error {
-	conn.buf.WriteByte(bitFlagDatagram | bitFlagNeedsBAndAS)
+func (conn *Conn) consumeSendBudget(size uint32) {
+	if size >= conn.sendBudget {
+		conn.sendBudget = 0
+		return
+	}
+	conn.sendBudget -= size
+}
+
+// signalSendQueueFreed wakes every writer waiting for send queue space. It must
+// be called with conn.mu held, which is what lets a writer capture the channel
+// and release the lock without racing a drain.
+func (conn *Conn) signalSendQueueFreed() {
+	close(conn.sendQueueFreed)
+	conn.sendQueueFreed = make(chan struct{})
+}
+
+// signalSend wakes the connection's send loop. Signals coalesce, so callers may
+// signal freely.
+func (conn *Conn) signalSend() {
+	select {
+	case conn.sendSignal <- struct{}{}:
+	default:
+	}
+}
+
+func (conn *Conn) sendDatagram(pk *packet, size uint32, retransmit bool) error {
+	header := byte(bitFlagDatagram)
+	if conn.congestion.slowStart() {
+		// The client sets this from its own slow start state, asking the peer
+		// to report bandwidth back while the window is still opening.
+		header |= bitFlagNeedsBAndAS
+	}
+	if conn.wireContinuous {
+		header |= bitFlagContinuousSend
+	}
+	conn.wireContinuous = true
+	conn.buf.WriteByte(header)
 	seq := conn.seq.Inc()
 	writeUint24(conn.buf, seq)
 	pk.write(conn.buf)
 	defer conn.buf.Reset()
 
 	if pk.reliability.reliable() {
-		// We then re-add the pk to the recovery queue in case the new one gets
-		// lost too, in which case we need to resend it again.
-		conn.retransmission.add(seq, pk)
+		conn.retransmission.add(seq, pk, size)
+		if !retransmit {
+			conn.congestion.sent(size)
+		}
 	}
 
 	if err := conn.writeTo(conn.buf.Bytes(), conn.raddr); err != nil {
+		if pk.reliability.reliable() {
+			delete(conn.retransmission.unacknowledged, seq)
+			conn.congestion.acknowledged(size)
+		}
+		pk.content = pk.content[:0]
+		packetPool.Put(pk)
 		return fmt.Errorf("send datagram: %w", err)
+	}
+	if !pk.reliability.reliable() {
+		pk.content = pk.content[:0]
+		packetPool.Put(pk)
 	}
 	return nil
 }

--- a/datagram_window.go
+++ b/datagram_window.go
@@ -15,14 +15,29 @@ func newDatagramWindow() *datagramWindow {
 	return &datagramWindow{queue: make(map[uint24]time.Time)}
 }
 
-// add puts an index in the window.
-func (win *datagramWindow) add(index uint24) bool {
-	if win.seen(index) {
-		return false
+// add puts an index in the window. skipped holds the indices the peer jumped
+// over, each marked so a gap is NACKed once, when it appears, as the client does.
+func (win *datagramWindow) add(index uint24) (ok bool, skipped []uint24) {
+	if index < win.lowest {
+		// Wire duplicate or reordered past the window. The client has no duplicate
+		// detection by datagram, so process it; ordered delivery drops true repeats.
+		return true, nil
+	}
+	if t, present := win.queue[index]; present {
+		if !t.IsZero() {
+			return false, nil
+		}
+		// Reported missing, but it was only reordered and has arrived after all.
+		win.queue[index] = time.Now()
+		return true, nil
+	}
+	for i := win.highest; i < index; i++ {
+		skipped = append(skipped, i)
+		win.queue[i] = time.Time{}
 	}
 	win.highest = max(win.highest, index+1)
 	win.queue[index] = time.Now()
-	return true
+	return true, skipped
 }
 
 // seen checks if the index passed is known to the datagramWindow.
@@ -47,31 +62,6 @@ func (win *datagramWindow) shift() (n int) {
 	}
 	win.lowest = index
 	return n
-}
-
-// missing returns a slice of all indices in the datagram queue that weren't
-// set using add while within the window of lowest and highest index. The queue
-// is shifted after this call.
-func (win *datagramWindow) missing(since time.Duration) (indices []uint24) {
-	missing := false
-	for index := int(win.highest) - 1; index >= int(win.lowest); index-- {
-		i := uint24(index)
-		t, ok := win.queue[i]
-		if ok {
-			if time.Since(t) >= since {
-				// All packets before this one took too long to arrive, so we
-				// mark them as missing.
-				missing = true
-			}
-			continue
-		}
-		if missing {
-			indices = append(indices, i)
-			win.queue[i] = time.Time{}
-		}
-	}
-	win.shift()
-	return indices
 }
 
 // size returns the size of the datagramWindow.

--- a/packet.go
+++ b/packet.go
@@ -15,10 +15,30 @@ const (
 	bitFlagACK = 0x40
 	// bitFlagNACK is set for every NACK packet.
 	bitFlagNACK = 0x20
+	// bitFlagContinuousSend indicates that more datagrams are immediately
+	// available to send.
+	bitFlagContinuousSend = 0x08
 	// bitFlagNeedsBAndAS is set for every datagram with packet data, but is not
 	// actually used.
 	bitFlagNeedsBAndAS = 0x04
 )
+
+func encapsulatedPacketSize(contentLength int, reliability reliability, split bool) int {
+	size := 3 + contentLength
+	if reliability.reliable() {
+		size += 3
+	}
+	if reliability.sequenced() {
+		size += 3
+	}
+	if reliability.sequencedOrOrdered() {
+		size += 4
+	}
+	if split {
+		size += splitAdditionalSize
+	}
+	return size
+}
 
 const (
 	// reliabilityUnreliable means that the packet sent could arrive out of
@@ -188,21 +208,32 @@ const (
 	splitAdditionalSize = 4 + 2 + 4
 )
 
-// split splits a content buffer in smaller buffers so that they do not exceed
-// the MTU size that the connection holds.
-func split(b []byte, mtu uint16) [][]byte {
-	n := len(b)
+// fragmentSize returns the payload each fragment of an n byte packet carries.
+func fragmentSize(n int, mtu uint16) int {
 	maxSize := int(mtu - packetAdditionalSize)
-
 	if n > maxSize {
 		// If the content size is bigger than the maximum size here, it means
 		// the packet will get split. This means that the packet will get even
 		// bigger because a split packet uses 4 + 2 + 4 more bytes.
 		maxSize -= splitAdditionalSize
 	}
+	return maxSize
+}
+
+// splitCount returns how many fragments an n byte packet is split into.
+func splitCount(n int, mtu uint16) int {
+	maxSize := fragmentSize(n, mtu)
 	// If the content length can't be divided by maxSize perfectly, we need
 	// to reserve another fragment for the last bit of the packet.
-	fragmentCount := n/maxSize + min(n%maxSize, 1)
+	return n/maxSize + min(n%maxSize, 1)
+}
+
+// split splits a content buffer in smaller buffers so that they do not exceed
+// the MTU size that the connection holds.
+func split(b []byte, mtu uint16) [][]byte {
+	n := len(b)
+	maxSize := fragmentSize(n, mtu)
+	fragmentCount := splitCount(n, mtu)
 	fragments := make([][]byte, fragmentCount)
 	for i := range fragmentCount - 1 {
 		fragments[i] = b[:maxSize]

--- a/packet.go
+++ b/packet.go
@@ -23,10 +23,8 @@ const (
 	bitFlagNeedsBAndAS = 0x04
 )
 
-// encapsulatedPacketSize returns the encoded size of one encapsulated packet:
-// the reliability header that varies with the reliability, the split header when
-// split, and the content. It excludes the 4-byte datagram header, so it is also
-// the number of bytes the packet counts against the congestion window.
+// encapsulatedPacketSize returns a packet's encoded size excluding the 4-byte
+// datagram header, which is also what it counts in flight.
 func encapsulatedPacketSize(contentLength int, reliability reliability, split bool) int {
 	size := 3 + contentLength
 	if reliability.reliable() {

--- a/packet.go
+++ b/packet.go
@@ -23,6 +23,10 @@ const (
 	bitFlagNeedsBAndAS = 0x04
 )
 
+// encapsulatedPacketSize returns the encoded size of one encapsulated packet:
+// the reliability header that varies with the reliability, the split header when
+// split, and the content. It excludes the 4-byte datagram header, so it is also
+// the number of bytes the packet counts against the congestion window.
 func encapsulatedPacketSize(contentLength int, reliability reliability, split bool) int {
 	size := 3 + contentLength
 	if reliability.reliable() {

--- a/resend_map.go
+++ b/resend_map.go
@@ -32,7 +32,8 @@ func newRecoveryQueue() *resendMap {
 	}
 }
 
-// add puts a packet at the index passed and records the current time.
+// add stores a packet under its datagram sequence number and schedules when to
+// retransmit it if no ACK arrives, one RTO from now.
 func (m *resendMap) add(index uint24, pk *packet, inFlightBytes uint32) {
 	now := time.Now()
 	nextSend := now.Add(m.rto())
@@ -95,6 +96,8 @@ func (m *resendMap) observeRTT(sample time.Duration) {
 	m.deviationRTT += time.Duration(float64(difference-m.deviationRTT) * 0.05)
 }
 
+// rtt returns the smoothed round-trip estimate, or a default until the first
+// datagram has been acknowledged.
 func (m *resendMap) rtt() time.Duration {
 	if !m.hasRTT {
 		return time.Millisecond * 50

--- a/resend_map.go
+++ b/resend_map.go
@@ -32,8 +32,8 @@ func newRecoveryQueue() *resendMap {
 	}
 }
 
-// add stores a packet under its datagram sequence number and schedules when to
-// retransmit it if no ACK arrives, one RTO from now.
+// add stores a packet by its sequence number and schedules the retransmit one
+// RTO out.
 func (m *resendMap) add(index uint24, pk *packet, inFlightBytes uint32) {
 	now := time.Now()
 	nextSend := now.Add(m.rto())
@@ -96,8 +96,7 @@ func (m *resendMap) observeRTT(sample time.Duration) {
 	m.deviationRTT += time.Duration(float64(difference-m.deviationRTT) * 0.05)
 }
 
-// rtt returns the smoothed round-trip estimate, or a default until the first
-// datagram has been acknowledged.
+// rtt returns the smoothed round-trip estimate, or a default before the first ACK.
 func (m *resendMap) rtt() time.Duration {
 	if !m.hasRTT {
 		return time.Millisecond * 50

--- a/resend_map.go
+++ b/resend_map.go
@@ -1,7 +1,6 @@
 package raknet
 
 import (
-	"maps"
 	"time"
 )
 
@@ -9,72 +8,105 @@ import (
 // the connection ended up not having them.
 type resendMap struct {
 	unacknowledged map[uint24]resendRecord
-	delays         map[time.Time]time.Duration
+	estimatedRTT   time.Duration
+	deviationRTT   time.Duration
+	hasRTT         bool
+	// deadline is a lower bound on the earliest nextSend of any record. It lets
+	// a frequently woken send loop skip the scan when nothing is due yet.
+	deadline time.Time
 }
 
 // resendRecord represents a single packet with a timestamp from when it was
 // initially sent. It may be either acknowledged or NACKed by the other end.
 type resendRecord struct {
-	pk        *packet
-	timestamp time.Time
+	pk            *packet
+	inFlightBytes uint32
+	timestamp     time.Time
+	nextSend      time.Time
 }
 
 // newRecoveryQueue returns a new initialised recovery queue.
 func newRecoveryQueue() *resendMap {
 	return &resendMap{
-		delays:         make(map[time.Time]time.Duration),
 		unacknowledged: make(map[uint24]resendRecord),
 	}
 }
 
 // add puts a packet at the index passed and records the current time.
-func (m *resendMap) add(index uint24, pk *packet) {
-	m.unacknowledged[index] = resendRecord{pk: pk, timestamp: time.Now()}
+func (m *resendMap) add(index uint24, pk *packet, inFlightBytes uint32) {
+	now := time.Now()
+	nextSend := now.Add(m.rto())
+	m.unacknowledged[index] = resendRecord{
+		pk: pk, inFlightBytes: inFlightBytes, timestamp: now, nextSend: nextSend,
+	}
+	m.lowerDeadline(nextSend)
+}
+
+// lowerDeadline keeps deadline a lower bound on every record's nextSend.
+func (m *resendMap) lowerDeadline(t time.Time) {
+	if m.deadline.IsZero() || t.Before(m.deadline) {
+		m.deadline = t
+	}
+}
+
+// due reports whether any record may have become eligible for retransmission.
+func (m *resendMap) due(now time.Time) bool {
+	return !m.deadline.IsZero() && !now.Before(m.deadline)
 }
 
 // acknowledge marks a packet with the index passed as acknowledged. The packet
 // is removed from the resendMap and returned if found.
-func (m *resendMap) acknowledge(index uint24) (*packet, bool) {
-	return m.remove(index, 1)
+func (m *resendMap) acknowledge(index uint24) (resendRecord, bool) {
+	record, ok := m.remove(index)
+	if ok {
+		m.observeRTT(time.Since(record.timestamp))
+	}
+	return record, ok
 }
 
 // retransmit looks up a packet with an index from the resendMap so that it may
 // be resent.
-func (m *resendMap) retransmit(index uint24) (*packet, bool) {
-	return m.remove(index, 2)
+func (m *resendMap) retransmit(index uint24) (resendRecord, bool) {
+	return m.remove(index)
 }
 
-// remove deletes an index from the resendMap and adds the time since the
-// packet was originally sent multiplied by mul to the delays slice.
-func (m *resendMap) remove(index uint24, mul int) (*packet, bool) {
+func (m *resendMap) remove(index uint24) (resendRecord, bool) {
 	record, ok := m.unacknowledged[index]
 	if !ok {
-		return nil, false
+		return resendRecord{}, false
 	}
 	delete(m.unacknowledged, index)
-
-	now := time.Now()
-	m.delays[now] = now.Sub(record.timestamp) * time.Duration(mul)
-	return record.pk, true
+	return record, true
 }
 
-// rtt returns the average round trip time between the putting of the value
-// into the recovery queue and the taking out of it again. It is measured over
-// the last delayRecordCount values add in.
-func (m *resendMap) rtt(now time.Time) time.Duration {
-	const rttCalculationWindow = time.Second * 5
-	maps.DeleteFunc(m.delays, func(t time.Time, duration time.Duration) bool {
-		// Remove records that are older than the max window.
-		return now.Sub(t) > rttCalculationWindow
-	})
-	if len(m.delays) == 0 {
-		// No records yet, generally should not happen. Just return a reasonable
-		// amount of time.
+// observeRTT smooths RTT and deviation so one unusual sample has little effect.
+func (m *resendMap) observeRTT(sample time.Duration) {
+	if !m.hasRTT {
+		m.estimatedRTT = sample
+		m.deviationRTT = sample
+		m.hasRTT = true
+		return
+	}
+	difference := sample - m.estimatedRTT
+	m.estimatedRTT += time.Duration(float64(difference) * 0.05)
+	if difference < 0 {
+		difference = -difference
+	}
+	m.deviationRTT += time.Duration(float64(difference-m.deviationRTT) * 0.05)
+}
+
+func (m *resendMap) rtt() time.Duration {
+	if !m.hasRTT {
 		return time.Millisecond * 50
 	}
-	var total time.Duration
-	for _, rtt := range m.delays {
-		total += rtt
+	return m.estimatedRTT
+}
+
+// rto uses the smoothed RTT and deviation. A record becomes eligible for
+// retransmission when its send time plus this duration has passed.
+func (m *resendMap) rto() time.Duration {
+	if !m.hasRTT {
+		return time.Second * 2
 	}
-	return total / time.Duration(len(m.delays))
+	return min(m.estimatedRTT*2+m.deviationRTT*4+time.Millisecond*30, time.Second*2)
 }


### PR DESCRIPTION
## Summary

Give the send path the congestion control and scheduling the vanilla Bedrock client uses, instead of emitting every datagram the moment it is written.

- ACK-driven congestion window with slow start, congestion avoidance, NAK recovery and timeout backoff
- reliable encapsulated bytes accounted in flight and released on ACK
- a 16 MiB bounded send queue with backpressure, and a reserve so control traffic keeps moving
- a per-record EWMA retransmission timeout, replacing the previous fixed resend trigger
- sends owned by the connection's own goroutine, so a window drain never runs on a `Listener`'s shared read loop
- acknowledgements batched for the client's SYN interval
- outstanding reliable datagrams bounded by the client's resend buffer size
- continuous-send and 24-bit sequence semantics preserved

## Why

Every datagram was emitted immediately, so a burst (a resource-pack transfer, say) was never constrained by receiver feedback. On a fast path that overruns the receiver: it loses fragments, the ordered stream stalls, and the connection either hangs or trips a window guard. On loopback, the current code fails every 16 MiB transfer and most 8 MiB transfers for this reason; with a bounded window they all complete.

## Notes on parity

Scheduling matches the behaviour of the vanilla Bedrock client. That behaviour differs from the classic RakNet sliding-window congestion algorithm in several places, so worth calling out explicitly:

- a NAK marks the congestion block as backed off, so it lowers the slow start threshold without collapsing the window; the classic algorithm drops the window to one MTU
- the congestion avoidance increase applies on every ACK, not once per congestion block
- retransmission bandwidth is the outstanding byte count, and retransmitted bytes do not consume the new-data budget
- the continuous-send flag carries the previous tick's sample, and is forced on for every datagram after the first in a tick
- new reliable data stops while the resend buffer is full, independently of the congestion window

## Receiver recovery timing

Adding the send-path window surfaced a receiver-side timing problem: `missing` waited 1.5x the round-trip estimate before scanning for holes and NACKing them, while the retransmission timeout is `2*RTT + 4*deviation + 30ms`. NACK recovery therefore lost the race against the timeout on nearly every loss, and each spurious timeout cut the window to one MTU — bulk transfers over lossy links ran at the timeout's pace, one collapse per round trip.

The vanilla client reports a gap the moment the datagram that jumped it arrives, and this branch now does the same: `add` returns the newly skipped indices and they are NACKed immediately, once, with the retransmission timeout as the only backstop. Duplicate detection by datagram narrows to match — an index reported missing but merely reordered is processed when it arrives, as is anything below the window; the client has no duplicate detection by datagram at all, and ordered delivery already drops true repeats.

Serving a 4.8 MB payload across a simulated link with 1% loss and 60 ms RTT: 20-27 s with the delayed scan, 3-5 s with gap-on-arrival reporting. At 5% loss and 100 ms RTT: timeout versus ~37 s. A link with periodic 400 ms outages completes instead of stalling past any application timeout.

## Measurements

Loopback, 4 KiB writes, dialer to listener, same host. `before` is the base without send-path congestion control.

| payload | before | this branch |
|---|---|---|
| 1 MiB | 3/3 completed | 3/3 completed |
| 8 MiB | 2/7 completed; 5 stalled indefinitely | 3/3 completed |
| 16 MiB | 1/3 completed; 2 closed early | 3/3 completed |

Loopback has no bottleneck link, so an unpaced sender always outruns the receive buffer — `master` is faster on the transfers it happens to complete and unusable on the rest. This trades peak throughput on that path for transfers that finish.

## Tests

The full deterministic test suite for this change — congestion state, ACK drain, backpressure and cancellation, control priority, retransmission accounting, RTO, sequence wrap, ACK batching, the resend buffer bound, and the disconnect flush — lives in the companion PR on our fork, kept out of this one to keep the diff focused on the change itself:

https://github.com/HashimTheArab/go-raknet/pull/15

That PR also carries a few unrelated fork changes; the congestion work is identical. Happy to port the tests into this PR if you would prefer them here.